### PR TITLE
Improve DSL example

### DIFF
--- a/tosca_2_0/TOSCA-v2.0.md
+++ b/tosca_2_0/TOSCA-v2.0.md
@@ -4595,7 +4595,7 @@ In the above grammar, the pseudo values that appear in angle brackets have the f
 
     <scalar-unit_type_name>: represents the mandatory name of the parent type which must be either scalar-unit or a data type derived from scalar-unit.
 
-    <data_type_name>: The TOSCA data type of the scalar. MUST be either TOSCA float, TOSCA intger or derived from them.
+    <data_type_name>: The TOSCA data type of the scalar. MUST be either TOSCA float, TOSCA integer or derived from them.
 
     <suffix>: An optional string. If not present then unit_symbol_name is equal to unit_symbol. If present then unit_symbol_name is equal to unit_symbol&&unit_suffix. It is provided as a convenience so that metric units can use YAML anchor and alias to avoid repeating the table of SI prefixes. The multiplier for unit_symbol_name has an implict value of 1.0
 

--- a/tosca_2_0/TOSCA-v2.0.md
+++ b/tosca_2_0/TOSCA-v2.0.md
@@ -1389,23 +1389,7 @@ where `<anchor_block>` defines a set of reusable YAML definitions (the
 `<anchor_definitions>`) for which `<anchor>` can be used as an alias
 elsewhere in the document.
 
-The following example shows DSL definitions for common image property
-assignments:
-<!----
-{"id": "236", "author": "Jordan,PM,Paul,TNK6 R", "date": "2020-11-05T11:18:00Z", "comment": "There should also be an example of how to use the macro once defined.", "target": "Example"}-->
-```
-dsl_definitions:
-    ubuntu_image_props: &ubuntu_image_props
-      architecture: x86_64
-      type: linux
-      distribution: ubuntu
-      os_version: '14.04'
-    redhat_image_props: &redhat_image_props
-      architecture: x86_64
-      type: linux
-      distribution: rhel
-      os_version: '6.6'
-```
+An example of the creation and subsequent use of a DSL defintion is shown in the section on Scalar type.s.
 
 ## 6.4 Type Definitions
 


### PR DESCRIPTION
Removed example of DSL defintion but in place added a textual cross reference to the section on Scalar unit which not only contains an example of creation of a DSL definition but also its subsequent use. (A hyperlink to the section using an anchor would be preferable but headers don't yet have anchors.) This is intended to resolve issue #96 which I originated. 