### PR TITLE
Provide example of DSL defintion use

### DIFF
--- a/tosca_2_0/TOSCA-v2.0.md
+++ b/tosca_2_0/TOSCA-v2.0.md
@@ -1360,22 +1360,7 @@ where `<anchor_block>` defines a set of reusable YAML definitions (the
 `<anchor_definitions>`) for which `<anchor>` can be used as an alias
 elsewhere in the document.
 
-The following example shows DSL definitions for common image property
-assignments:
-
-```
-dsl_definitions:
-    ubuntu_image_props: &ubuntu_image_props
-      architecture: x86_64
-      type: linux
-      distribution: ubuntu
-      os_version: '14.04'
-    redhat_image_props: &redhat_image_props
-      architecture: x86_64
-      type: linux
-      distribution: rhel
-      os_version: '6.6'
-```
+An example of defining and using a DSL definition, a YAML anchor, is given in [scalar-unit](#scalar-unit).
 
 ## 6.4 Type Definitions <a name=type-definitions></a>
 
@@ -4530,6 +4515,20 @@ In the above grammar, the pseudo values that appear in angle brackets have the f
 
 The following gives an example of the use of a scalar_units:
 ```yaml
+dsl_definitions:
+  # Defined a reusable list of prefixes taken from ISO80000
+   ISO_prefixes: &ISO80000
+         # symbols for smaller multipliers ommitted for brevity
+      μ: 0.0001
+      m: 0.001
+      c: 0.01
+      d: 0.1
+      da: 10 # symbols may be muliple characters
+      h: 100 # integer auto converted to float
+      k: 1000
+      M: 1000000
+      # symbols for larger multipliers omiited
+
 data_types:
   non_negative_number:
     derived_from: float
@@ -4553,17 +4552,7 @@ data_types:
 
   length:
     derived_from: scalar-unit
-    unit_symbol_map: &ISO80000
-      # symbols for smaller multipliers ommitted for brevity
-      μ: 0.0001
-      m: 0.001
-      c: 0.01
-      d: 0.1
-      da: 10 # symbols may be muliple characters
-      h: 100 # integer auto converted to float
-      k: 1000
-      M: 1000000
-      # symbols for larger multipliers omiited
+    unit_symbol_map: *ISO80000 # First use of the YAML anchor and alias
     unit_suffix: m  ## Note suffix is defined so will be appended to entries in the unit_symbol_map
 
   mass:

--- a/tosca_2_0/TOSCA-v2.0.md
+++ b/tosca_2_0/TOSCA-v2.0.md
@@ -4595,7 +4595,7 @@ In the above grammar, the pseudo values that appear in angle brackets have the f
 
     <scalar-unit_type_name>: represents the mandatory name of the parent type which must be either scalar-unit or a data type derived from scalar-unit.
 
-    <data_type_name>: The TOSCA data type of the scalar. MUST be either TOSCA float, TOSCA intger or derived from them.
+    <data_type_name>: The TOSCA data type of the scalar. MUST be either TOSCA float, TOSCA integer or derived from them.
 
     <suffix>: An optional string. If not present then unit_symbol_name is equal to unit_symbol. If present then unit_symbol_name is equal to unit_symbol&&unit_suffix. It is provided as a convenience so that metric units can use YAML anchor and alias to avoid repeating the table of SI prefixes. The multiplier for unit_symbol_name has an implict value of 1.0
 


### PR DESCRIPTION
Remove previous example of DLS definition. Replace it with a reference to scalar-unit which already has an example of YAML anchor. Update example in scalar-unit to use the dsl defintion section. This is to resolve my issue #96 