### PR TITLE
Move links

### DIFF
--- a/tosca_2_0/TOSCA-v2.0.md
+++ b/tosca_2_0/TOSCA-v2.0.md
@@ -246,7 +246,7 @@ encourage consistent readability within the TOSCA ecosystem.
 * *TOSCA primitive type names*: we prefer single lower-case whole words: `string`,
   `integer`, `float`, `boolean`. Note that previous versions of TOSCA also had types
   with the `scalar-unit.` prefix, however we now prefer to to use single lower-case
-  words for these. See [`scalar-unit`](#9122-scalar-unit) for more examples.
+  words for these. See [scalar-unit](#scalar-unit) for more examples.
 * *TOSCA function names*: snake case. This includes the built-in functions as well
   as custom functions. Examples: `$greater_than`, `$has_any_key`,
   `$my_custom_function`.
@@ -3323,7 +3323,7 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[type](#capability-type)|yes|[string](#string)|The mandatory name of the capability type on which this capability definition is based.|
+|type|yes|[string](#string)|The mandatory name of the [capability type](#capability-type) on which this capability definition is based.|
 |description|no|[string](#string)|The optional [description](#description) of the Capability definition.|
 |metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
 |properties|no|[map](#map) of [property refinements](#property-definition)|An optional map of property refinements for the capability definition. The referred properties must have been defined in the capability type definition referred by the type keyword. New properties may not be added.|
@@ -3451,7 +3451,7 @@ assignment:
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 |properties|no|[map](#map) of  [property assignments](#property-definition)|An optional map of property assignments for the capability definition.|
-|[attributes](#attribute-definition)|no|[map](#map) of attribute assignments|An optional map of attribute assignments for the capability definition.|
+|attributes|no|[map](#map) of [attribute assignments](#attribute-definition)|An optional map of attribute assignments for the capability definition.|
 |directives|no|An optional list of directive values to provide processing instructions to orchestrators and tooling.|
 
 
@@ -3542,12 +3542,12 @@ support the following keynames:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[type](#relationship-types)|yes|[string](#string)|The mandatory keyname used to provide the name of the relationship type used for the relationship.|
+|type|yes|[string](#string)|The mandatory keyname used to provide the name of the [relationship type](#relationship-types) used for the relationship.|
 |description|no|[string](#string)|The optional [description](#description) of the relationship definition.|
 |metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
 |properties|no|[map](#map) of [property refinements](#property-definition)|An optional map of property refinements for the relationship definition. The referred properties must have been defined in the relationship type definition referred by the type keyword. New properties may not be added.|
-|[attributes](#attribute-definition)|no|[map](#map) of [attribute refinements](#attribute-definition)|An optional map of attribute refinements for the relationship definition. The referred attributes must have been defined in the relationship type definition referred by the type keyword. New attributes may not be added.|
-|[interfaces](#interface-definition)|no|[map](#map) of interface refinements|The optional keyname used to define interface refinements for interfaces defined by the relationship type.|
+|attributes|no|[map](#map) of [attribute refinements](#attribute-definition)|An optional map of attribute refinements for the relationship definition. The referred attributes must have been defined in the relationship type definition referred by the type keyword. New attributes may not be added.|
+|interfaces|no|[map](#map) of [interface refinements](#interface-definition)|The optional keyname used to define interface refinements for interfaces defined by the relationship type.|
 
 The keynames supported by requirement definitions and relationship
 definitions can be used according to the following grammar:
@@ -3714,7 +3714,7 @@ assignment:
 |capability|no|[string](#string)|The optional keyname used to identify the target capability of the requirement. This can either be the name of a capability defined within a target node or the name of a target capability type that the TOSCA orchestrator will use to select a type-compatible target node to fulfill the requirement at runtime. |
 |relationship|conditional|relationship assignment or string|The conditional keyname used to provide values for the relationship definition in the corresponding requirement definition. This keyname can also be overloaded to define a symbolic name that references a relationship template defined elsewhere in the service template.|
 |allocation|no|allocation block|The optional keyname that allows the inclusion of an allocation block. The allocation block contains a map of property assignments that semantically represent *allocations* from the property with the same name in the target capability. The allocation acts as a *capacity filter* for the target capability in the target node. When the requirement is resolved, a capability in a node is a valid target for the requirement relationship if for each property of the target capability, the sum of all existing allocations plus the current allocation is less_or_equal to the property value.|
-|[count](#cardinality-of-relationships)|no|non-negative integer|An optional keyname that sets the cardinality of the requirement assignment, that is how many relationships must be established from this requirement assignment. If not defined, the default count for an assignment is 1. Note that there can be multiple requirement assignments for a requirement with a specific symbolic name. The sum of all count values of assignments for a requirement with a specific symbolic name must be within the count_range defined in the requirement definition. Moreover, the sum of all count values of non-optional assignments for a requirement with a specific symbolic name must also be within the count_range defined in the requirement definition.|
+|count|no|non-negative integer|An optional keyname that sets the [cardinality of the requirement assignment](#cardinality-of-relationships), that is how many relationships must be established from this requirement assignment. If not defined, the default count for an assignment is 1. Note that there can be multiple requirement assignments for a requirement with a specific symbolic name. The sum of all count values of assignments for a requirement with a specific symbolic name must be within the count_range defined in the requirement definition. Moreover, the sum of all count values of non-optional assignments for a requirement with a specific symbolic name must also be within the count_range defined in the requirement definition.|
 |node_filter|no|[node filter](#node-filter-definition)|The optional filter definition that TOSCA orchestrators will use to select a type-compatible target node that can fulfill the requirement at runtime.|
 |directives|no|[list](#list) of [string](#string)|An optional list of directive values to provide processing instructions to orchestrators and tooling.|
 |optional|no|[boolean](#boolean)|Describes if the fulfillment of this requirement assignment is optional (true) or not (false).  If not specified, the requirement assignment must be fulfilled, i.e. the default value is false.  Note also, that non-optional requirements have precedence, thus during a service deployment, the optional requirements for all nodes should be resolved only after the non-optional requirements for all nodes have been resolved.|
@@ -3727,10 +3727,10 @@ support the following keynames:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[type](#relationship-types)|no|[string](#string)|The optional keyname used to provide the name of the relationship type for the requirement assignment’s relationship.|
+|type|no|[string](#string)|The optional keyname used to provide the name of the [relationship type](#relationship-types) for the requirement assignment’s relationship.|
 |properties|no|[map](#map) of [property assignments](#property-definition)|An optional map of property assignments for the relationship.|
-|[attributes](#attribute-assignment)|no|[map](#map) of attribute assignments|An optional map of attribute assignments for the relationship.|
-|[interfaces](#interface-assignment)|no|[map](#map) of interface assignments|An optional map of interface assignments for the corresponding interface definitions in the relationship type.|
+|attributes|no|[map](#map) of [attribute assignments](#attribute-assignment)|An optional map of attribute assignments for the relationship.|
+|interfaces|no|[map](#map) of [interface assignments](#interface-assignment)|An optional map of interface assignments for the corresponding interface definitions in the relationship type.|
 
 ### 8.5.2 Requirement Assignment Grammar <a name=requirement-assignment-grammar></a>
 
@@ -4633,19 +4633,19 @@ A concrete scalar type is defined using the following grammar:
 ```
 In the above grammar, the pseudo values that appear in angle brackets have the following meaning:
 
-    <scalar-unit_type_name>: represents the mandatory name of the parent type which must be either scalar-unit or a data type derived from scalar-unit.
+<scalar-unit_type_name>: represents the mandatory name of the parent type which must be either scalar-unit or a data type derived from scalar-unit.
 
-    <data_type_name>: The TOSCA data type of the scalar. MUST be either TOSCA float, TOSCA integer or derived from them.
+<data_type_name>: The TOSCA data type of the scalar. MUST be either TOSCA float, TOSCA integer or derived from them.
 
-    <suffix>: An optional string. If not present then unit_symbol_name is equal to unit_symbol. If present then unit_symbol_name is equal to unit_symbol&&unit_suffix. It is provided as a convenience so that metric units can use YAML anchor and alias to avoid repeating the table of SI prefixes. The multiplier for unit_symbol_name has an implict value of 1.0
+<suffix>: An optional string. If not present then unit_symbol_name is equal to unit_symbol. If present then unit_symbol_name is equal to unit_symbol&&unit_suffix. It is provided as a convenience so that metric units can use YAML anchor and alias to avoid repeating the table of SI prefixes. The multiplier for unit_symbol_name has an implict value of 1.0
 
-    <unit_symbol> A name string, with no white space, used to identify the unit.
+<unit_symbol> A name string, with no white space, used to identify the unit.
 
-    <unit_symbol_multiplier> A value of type TOSCA float which MUST be used by a TOSCA parser to convert values with the symbol into values in the base unit.
+<unit_symbol_multiplier> A value of type TOSCA float which MUST be used by a TOSCA parser to convert values with the symbol into values in the base unit.
 
-    Note that unit_symbol_name, unit_symbol and unit_suffix are all case sensitive.
+Note that unit_symbol_name, unit_symbol and unit_suffix are all case sensitive.
 
-The following gives an example of the use of a scalar_units:
+The following gives an example of the use of scalar_units:
 ```yaml
 dsl_definitions:
   # Defined a reusable list of prefixes taken from ISO80000
@@ -5115,7 +5115,7 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 | ----- | ------- | ----- | ------- |
-|[type](#data-types)|yes|[string](#string)|The mandatory data type for the key or entry. If this schema definition is for a map key, then the referred type must be derived originally from string.|
+|type|yes|[string](#string)|The mandatory [data type](#data-types) for the key or entry. If this schema definition is for a map key, then the referred type must be derived originally from string.|
 |description|no|[string](#string)|The optional [description](#description) for the schema.|
 |validation|no|[validation clause](#validation-clause)|The optional validation clause that must evaluate to True for the property.|
 |key_schema|no|schema definition|When the schema itself is of type map, the optional schema definition that is used to specify the type of the keys of that map’s entries (if key_schema is not defined it is assumed to be “string” by default). For other schema types, the key_schema must not be defined.|
@@ -5192,7 +5192,7 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 | ----- | ------- | ----- | ------- |
-|[type](#data-type)|yes|[string](#string)|The mandatory data type for the property.|
+|type|yes|[string](#string)|The mandatory [data type](#data-type) for the property.|
 |description|no|[string](#string)|The optional [description](#description) for the property.|
 |metadata|no|[map](#map) of yaml values|Defines a section used to declare additional [metadata](#metadata) information. |
 |required|no|[boolean](#boolean)|An optional key that declares a property as required (true) or not (false). Defaults to true.|
@@ -5418,7 +5418,7 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 | ----- | ------- | ----- | ------- |
-|[type](#data-type)|yes|[string](#string)|The mandatory data type for the attribute.|
+|type|yes|[string](#string)|The mandatory [data type](#data-type) for the attribute.|
 |description|no|[string](#string)|The optional [description](#description) for the attribute.|
 |metadata|no|[map](#map) of yaml data|Defines a section used to declare additional [metadata](#metadata) information. |
 |default|no|\<must match attribute type\>|An optional key that may provide a value to be used as a default if not provided by another means. This value SHALL be type compatible with the type declared by the attribute definition’s type keyname.|
@@ -5577,7 +5577,7 @@ definition with the following additional or changed keynames:
 
 |Keyname|Mandatory|Type|Description|
 | ----- | ------- | ----- | ------- |
-|[type](#data-type)|no|[string](#string)|The data type of the parameter. While this keyname is mandatory for a TOSCA Property definition, it is not mandatory for a TOSCA parameter definition.|
+|type|no|[string](#string)|The [data type](#data-type) of the parameter. While this keyname is mandatory for a TOSCA Property definition, it is not mandatory for a TOSCA parameter definition.|
 |value|no|\<must match parameter type\>|The type-compatible value to assign to the parameter.  Parameter values may be provided as the result from the evaluation of an expression or a function. May only be defined for outgoing parameters. Mutually exclusive with the *mapping* keyname.|
 |mapping|no|attribute selection format|A mapping that specifies the node or relationship attribute into which the returned output value must be stored. May only be defined for incoming parameters. Mutually exclusive with the *value* keyname.|
 
@@ -6120,7 +6120,7 @@ following table:
 
 |Argument|Mandatory|Type|Description|
 | ----- | ------- | ----- | ----- | 
-|[tosca_path](#tosca-path)|yes|a comma separated sequence of [string](#string) and non-negative [integer](#integer) as defined in [tosca_path](#tosca-path)|Using the \<tosca_path\> we can traverse the representation graph to extract information from a certain node or relationship. We start from a specific node or relationship identified by its symbolic name (or by the SELF keyword representing the node or relationship containing the definition) and then we may further traverse the relationships and nodes of the representation graph (using a variable number of steps) until reaching the desired node or relationship. The syntax is described in [the section TOSCA Path](#tosca-path). |
+|tosca_path|yes|a comma separated sequence of [string](#string) and non-negative [integer](#integer) as defined in [tosca_path](#tosca-path)|Using the \<tosca_path\> we can traverse the representation graph to extract information from a certain node or relationship. We start from a specific node or relationship identified by its symbolic name (or by the SELF keyword representing the node or relationship containing the definition) and then we may further traverse the relationships and nodes of the representation graph (using a variable number of steps) until reaching the desired node or relationship. The syntax is described in [the section TOSCA Path](#tosca-path). |
 |property_name|yes|[string](#string)|The name of the property definition from which the function will return the value.|
 |nested_property_name_or_index_*|no|[list](#list) of [string](#string) or [integer](#integer)|Some TOSCA properties are complex (i.e., composed as nested structures).  These parameters are used to dereference into the names of these nested structures when needed.  Some properties represent list types. In these cases, an index may be provided to reference a specific entry in the list (as identified by the previous parameter) to return. |
 
@@ -6242,7 +6242,7 @@ following table:
 
 |Argument|Mandatory|Type|Description|
 | ----- | ------- | ----- | ----- | 
-|[tosca_path](#tosca-path)|yes|a comma separated sequence of [string](#string) and non-negative [integer](#integer) as defined in [tosca_path](#tosca-path)|Using the \<tosca_path> we can traverse the representation graph to extract information from a certain node or relationship. The syntax is described in [the section TOSCA Path](#tosca-path).|
+|tosca_path|yes|a comma separated sequence of [string](#string) and non-negative [integer](#integer) as defined in [tosca_path](#tosca-path)|Using the \<tosca_path> we can traverse the representation graph to extract information from a certain node or relationship. The syntax is described in [the section TOSCA Path](#tosca-path).|
 |attribute_name|yes|The name of the attribute definition the function will return the value from.|
 |nested_attribute_name_or_index_*|no|[list](#list) of [string](#string) or [integer](#integer)|Some TOSCA attributes are complex (i.e., composed as nested structures).  These parameters are used to dereference into the names of these nested structures when needed.    Some attributes represent list types. In these cases, an index may be provided to reference a specific entry in the list (as identified by the previous parameter) to return. |
 
@@ -6264,7 +6264,7 @@ following table:
 
 |Argument|Mandatory|Type|Description|
 | ----- | ------- | ----- | ----- |
-|[tosca_path](#tosca-path)|yes|a comma separated sequence of [string](#string) and non-negative [integer](#integer) as defined in [tosca_path](#tosca-path)|Using the <tosca_path a TOSCA processor can traverse the representation graph to the node that contains the artifact. The syntax is described in [the section TOSCA Path](#tosca-path).|
+|tosca_path|yes|a comma separated sequence of [string](#string) and non-negative [integer](#integer) as defined in [tosca_path](#tosca-path)|Using the <tosca_path a TOSCA processor can traverse the representation graph to the node that contains the artifact. The syntax is described in [the section TOSCA Path](#tosca-path).|
 |artifact_name|yes|[string](#string)|The name of the artifact definition for which the function will return the location.|
 
 The following example uses a snippet of a WordPress
@@ -6354,7 +6354,7 @@ following table:
 
 |Argument|Mandatory|Type|Description|
 | ----- | ------- | ----- | ----- | 
-|[tosca_path](#tosca-path)|yes|a comma separated sequence of [string](#string) and non-negative [integer](#integer) as defined in [tosca_path](#tosca-path)|Using the \<tosca_path\> we can traverse the representation graph to extract information from a certain node or relationship. In this case the \<tosca_path\> must lead to a capability context. |
+|tosca_path|yes|a comma separated sequence of [string](#string) and non-negative [integer](#integer) as defined in [tosca_path](#tosca-path)|Using the \<tosca_path\> we can traverse the representation graph to extract information from a certain node or relationship. In this case the \<tosca_path\> must lead to a capability context. |
 |property_name|yes|[string](#string)|The name of the capability property definition from which the function will return the value. In this case it must be a allocatable property (i.e. of integer, float, or scalar property types).|
 
 Usage example:
@@ -6923,7 +6923,7 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 |:---- | :------ | :---- | :------ |
-|[signatures](#function-definitions)|yes|[map](#map) of signature definitions|The map of signature definitions.|
+|signatures|yes|[map](#map) of [signature definitions](#function-definitions)|The map of signature definitions.|
 |description|no|[string](#string)| The [description](#description) of the function.|
 |metadata|no|[map](#map) of metadata|Defines additional [metadata](#metadata) information.|
 
@@ -7251,8 +7251,8 @@ interface type definition has the following recognized keynames:
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 |inputs|no|[map](#map) of [parameter definitions](#input-parameters)|The optional map of input parameter definitions available to all operations defined for this interface.|
-|[operations](#operation-definition)|no|[map](#map) of operation definitions|The optional map of operations defined for this interface.|
-|[notifications](#notification-definition)|no|[map](#map) of notification definitions|The optional map of notifications defined for this interface.|
+|operations|no|[map](#map) of [operation definitions](#operation-definition)|The optional map of operations defined for this interface.|
+|notifications|no|[map](#map) of [notification definitions](#notification-definition)|The optional map of notifications defined for this interface.|
 
 These keynames can be used according to the following grammar:
 ```yaml
@@ -7329,12 +7329,12 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[type](#interface-types)|yes|[string](#string)|The mandatory name of the interface type on which this interface definition is based.|
+|type|yes|[string](#string)|The mandatory name of the [interface type](#interface-types) on which this interface definition is based.|
 |description|no|[string](#string)|The optional [description](#description) for this interface definition.|
 |metadata|no|[map](#map) of metadata|Defines additional [metadata](#metadata) information.|
 |inputs|no|[map](#map) of [parameter definitions and refinements](#input-parameters)|The optional map of input parameter refinements and new input parameter definitions available to all operations defined for this interface (the input parameters to be refined have been defined in the interface type definition).|
-|[operations](#operation-definition)|no|[map](#map) of operation refinements|The optional map of operations refinements for this interface. The referred operations must have been defined in the interface type definition.|
-|[notifications](#notification-definition)|no|[map](#map) of notification refinements|The optional map of notifications refinements for this interface. The referred operations must have been defined in the interface type definition.|
+|operations|no|[map](#map) of [operation refinements](#operation-definition)|The optional map of operations refinements for this interface. The referred operations must have been defined in the interface type definition.|
+|notifications|no|[map](#map) of [notification refinements](#notification-definition)|The optional map of notifications refinements for this interface. The referred operations must have been defined in the interface type definition.|
 
 Interface definitions in node or relationship type definitions have the
 following grammar:
@@ -7415,8 +7415,8 @@ assignment:
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 |inputs|no|[map](#map) of [parameter value assignments](#input-parameters)|The optional map of input parameter assignments. Template authors MAY provide parameter assignments for interface inputs that are not defined in their corresponding interface type.|
-|[operations](#operation-definition)|no|[map](#map) of operation assignments|The optional map of operations assignments specified for this interface.|
-|[notifications](#notification-definition)|no|[map](#map) of notification assignments|The optional map of notifications assignments specified for this interface.|
+|operations|no|[map](#map) of [operation assignments](#operation-definition)|The optional map of operations assignments specified for this interface.|
+|notifications|no|[map](#map) of [notification assignments](#notification-definition)|The optional map of notifications assignments specified for this interface.|
 
 Interface assignments have the following grammar:
 ```yaml
@@ -8041,9 +8041,9 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[type](#artifact-type)|yes|[string](#string)|The mandatory artifact type for the artifact definition.|
+|type|yes|[string](#string)|The mandatory [artifact type](#artifact-type) for the artifact definition.|
 |file|yes|[string](#string)|The mandatory URI string (relative or absolute) that can be used to locate the artifact’s file.|
-|[repository](#repository-definitions)|no|[string](#string)|The optional name of the repository definition that contains the location of the external repository that contains the artifact. The artifact is expected to be referenceable by its file URI within the repository.|
+|repository|no|[string](#string)|The optional name of the [repository definition](#repository-definitions) that contains the location of the external repository that contains the artifact. The artifact is expected to be referenceable by its file URI within the repository.|
 |description|no|[string](#string)|The optional [description](#description) for the artifact definition.|
 |metadata|no|[map](#map) of metadata|Defines additional [metadata](#metadata) information.|
 |artifact_version|no|[string](#string)|The version of this artifact. One use of this artifact_version is to declare the particular version of this artifact type, in addition to its mime_type (that is declared in the artifact type definition). Together with the mime_type it may be used to select a particular artifact processor for this artifact. For example, a python interpreter that can interpret python version 2.7.0.|
@@ -8512,7 +8512,7 @@ The grammar for the `count` keyword is as follows:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[count](#specifying-number-of-node-representations)|no|[integer](#integer)|The optional number of nodes in the representation graph that will be created from this node template. If not specified,  one single node is created.|
+|count|no|[integer](#integer)|The optional [number of nodes](#specifying-number-of-node-representations) in the representation graph that will be created from this node template. If not specified,  one single node is created.|
 
 It is expected that the value of the `count` is provided as an input
 to the service template. This enables the creation of a simplified
@@ -10273,11 +10273,11 @@ TOSCA group definition:
 
 |Keyname|Mandatory|Type|Description|
 | ----- | ------- | ----- | ------- |
-|[type](#group-types)|yes|[string](#string)|The mandatory name of the group type the group definition is based upon.|
+|type|yes|[string](#string)|The mandatory name of the [group type](#group-types) the group definition is based upon.|
 |description|no|[string](#string)|The optional [description](#description) for the group definition.|
 |metadata|no|[map](#map) of YAML data|Defines a section used to declare additional [metadata](#metadata) information. |
 |properties|no|[map](#map) of [property assignments](#property-definition)|An optional map of property value assignments for the group definition.|
-|[attributes](#attribute-definition)|no|[map](#map) of attribute assignments|An optional map of attribute value assignments for the group definition.|
+|attributes|no|[map](#map) of [attribute assignments](#attribute-definition)|An optional map of attribute value assignments for the group definition.|
 |members|no|[list](#list) of [string](#string)|The optional list of one or more node template names that are members of this group definition.|
 
 Group definitions have one the following grammars:
@@ -10342,7 +10342,7 @@ policy type definition has the following recognized keynames:
 | ----- | ------- | ----- | ------- |
 |properties|no|[map](#map) of (property definitions)(#property-definition)|An optional map of property definitions for the policy type.|
 |targets|no|[list](#list) of [string](#string)|An optional list of valid node types or group types the policy type can be applied to.|
-|[triggers](#trigger-definition)|no|[map](#map) of trigger definitions |An optional map of policy triggers for the policy type.|
+|triggers|no|[map](#map) of [trigger definitions](#trigger-definition) |An optional map of policy triggers for the policy type.|
 
 Policy types have the following grammar:
 ```yaml
@@ -10408,12 +10408,12 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 | ----- | ------- | ----- | ------- |
-|[type](#policy-type)|yes|[string](#string)|The mandatory name of the policy type the policy definition is based upon.|
+|type|yes|[string](#string)|The mandatory name of the [policy type](#policy-type) the policy definition is based upon.|
 |description|no|[string](#string)|The optional [description](#description) for the policy definition.|
 |metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
 |properties|no|[map](#map) of [property assignments](#property-definition)|An optional map of property value assignments for the policy definition.|
 |targets|no|[list](#list) of [string](#string)|An optional list of valid node templates or Groups the Policy can be applied to.|
-|[triggers](#trigger-definition)|no|[map](#map) of trigger definitions|An optional map of trigger definitions to invoke when the policy is applied by an orchestrator against the associated TOSCA entity. These triggers apply in addition to the triggers defined in the policy type.|
+|triggers|no|[map](#map) of [trigger definitions](#trigger-definition)|An optional map of trigger definitions to invoke when the policy is applied by an orchestrator against the associated TOSCA entity. These triggers apply in addition to the triggers defined in the policy type.|
 
 Policy definitions have the following grammar:
 ```yaml

--- a/tosca_2_0/TOSCA-v2.0.md
+++ b/tosca_2_0/TOSCA-v2.0.md
@@ -1282,23 +1282,23 @@ The following is the list of recognized keynames for a TOSCA file:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[tosca_definitions_version](#tosca-definitions-version)|yes|[string](#string)|Defines the version of the TOSCA specification used in this TOSCA file.|
+|tosca-definitions-version|yes|[string](#string)|Defines the [tosca_definitions_version](#tosca-definitions-version) of the TOSCA specification used in this TOSCA file.|
 |description|no|[string](#string)|Declares a [description](#description) for this TOSCA file and its contents.|
 |metadata|no|[map](#map) of YAML values|Defines a section used to declare additional [metadata](#metadata) information. Domain-specific TOSCA profile specifications may define keynames that are mandatory for their implementations.|
-|[dsl_definitions](#dsl-definitions)|no|N/A|Defines reusable YAML macros (i.e., YAML alias anchors) for use throughout this TOSCA file.|
-|[artifact_types](#artifact-type)|no|[map](#map) of artifact types|Declares a map of artifact type definitions for use in this TOSCA file and/or external TOSCA files.|
-|[data_types](#data-types)|no|map of data types|Declares a map of TOSCA data type definitions for use in this TOSCA file and/or external TOSCA files.|
-|[capability_types](#capability-types)|no|map of capability types|Declares a map of capability type definitions for use in this TOSCA file and/or external TOSCA files.|
-|[interface_types](#interface-types)|no|map of interface types|Declares a map of interface type definitions for use in this TOSCA file and/or external TOSCA files.|
-|[relationship_types](#relationship-type)|no|map of relationship types|Declares a map of relationship type definitions for use in this TOSCA file and/or external TOSCA files.|
-|[node_types](#node-type)|no|map of node types|Declares a map of node type definitions for use in this TOSCA file and/or external TOSCA files.|
-|[group_types](#group-types)|no|map of group types|Declares a map of group type definitions for use in this TOSCA file and/or external TOSCA files.|
-|[policy_types](#policy-types)|no|map of policy types|Declares a map of policy type definitions for use in this TOSCA file and/or external TOSCA files.|
-|[repositories](#repository-definitions)|no|map of repository definitions|Declares a map of external repositories that contain artifacts that are referenced in this TOSCA file along with the addresses used to connect to them in order to retrieve the artifacts.|
-|[functions](#function-definitions)|no|map of function definitions|Declares a map of function definitions for use in this TOSCA file and/or external TOSCA files.|
-|[profile](#profiles)|no|[string](#string)|The profile name that can be used by other TOSCA files to import the type definitions in this document.|
-|[imports](#import-definitions)|no|[list](#list) of import definitions|Declares a list of import statements pointing to external TOSCA files or well-known profiles. For example, these may be file locations or URIs relative to the TOSCA file within the same TOSCA CSAR file.|
-|[service_template](#service-template-definition)|no|service template definition|Defines a template from which to create a mode/representation of an application or service. Service templates consist of node templates that represent the application's or service's components, as well as relationship templates representing relations between these components.|
+|dsl_definitions|no|N/A|Defines [reusable YAML macros](#dsl-definitions) (i.e., YAML alias anchors) for use throughout this TOSCA file.|
+|artifact_types|no|[map](#map) of [artifact types](#artifact-type)|Declares a map of artifact type definitions for use in this TOSCA file and/or external TOSCA files.|
+|data_types|no|[map](#map) of [data types](#data_types)|Declares a map of TOSCA data type definitions for use in this TOSCA file and/or external TOSCA files.|
+|capability_types|no|[map](#map) of [capability types](#capability-types)|Declares a map of capability type definitions for use in this TOSCA file and/or external TOSCA files.|
+|interface_types|no|[map](#map) of [interface types](#interface-types)|Declares a map of interface type definitions for use in this TOSCA file and/or external TOSCA files.|
+|relationship_types|no|[map](#map) of [relationship types](#relationship-type)|Declares a map of relationship type definitions for use in this TOSCA file and/or external TOSCA files.|
+|node_types|no|[map](#map) of [node types](#node-type)|Declares a map of node type definitions for use in this TOSCA file and/or external TOSCA files.|
+|group_types|no|[map](#map) of [group types](#group-types)|Declares a map of group type definitions for use in this TOSCA file and/or external TOSCA files.|
+|policy_types|no|[map](#map) of [policy types](#policy-types)|Declares a map of policy type definitions for use in this TOSCA file and/or external TOSCA files.|
+|repositories|no|[map](#map) of [repository definitions](#repository-definitions)|Declares a map of external repositories that contain artifacts that are referenced in this TOSCA file along with the addresses used to connect to them in order to retrieve the artifacts.|
+|functions|no|[map](#map) of [function definitions](#function-definitions)|Declares a map of function definitions for use in this TOSCA file and/or external TOSCA files.|
+|profile|no|[string](#string)|The [profile](#profiles) name that can be used by other TOSCA files to import the type definitions in this document.|
+|imports|no|[list](#list) of [import definitions](#import-definitions)|Declares a list of import statements pointing to external TOSCA files or well-known profiles. For example, these may be file locations or URIs relative to the TOSCA file within the same TOSCA CSAR file.|
+|service_template|no|[service template definition](#service-template-definition)|Defines a template from which to create a mode/representation of an application or service. Service templates consist of node templates that represent the application's or service's components, as well as relationship templates representing relations between these components.|
 
 The following rules apply:
 
@@ -1393,7 +1393,7 @@ way. This section serves to define them at once.
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 |derived_from|no|[string](#string)|An optional parent type name from which this type derives.|
-|[version](#version)|no|[version](#version)|An optional version for the type definition.|
+|version|no|[version](#version)|An optional version for the type definition.|
 |metadata|no|[map](#map) of YAML values|Defines a section used to declare additional [metadata](#metadata) information.
 |description|no|[string](#string)|An optional [description](#description) for the type.|
 
@@ -2010,12 +2010,12 @@ definition:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[url](#importing-tosca-file)|conditional|[string](#string)|The url that references a TOSCA file to be imported. An import statement must include either a url or a profile, but not both.|
-|[profile](#profiles)|conditional|[string](#string)|The profile name that references a named type profile to be imported. An import statement must include either a url or a profile, but not both.|
-|[repository](#repository-definitions)|conditional|[string](#string)|The optional symbolic name of the repository definition where the imported file can be found as a string. The repository name can only be used when a url is specified.|
-|[namespace](#namespaces)|no|[string](#string)|The optional name of the namespace into which to import the type definitions from the imported template or profile.|
+|url|conditional|[string](#string)|The [url](#importing-tosca-file) that references a TOSCA file to be imported. An import statement must include either a url or a profile, but not both.|
+|profile|conditional|[string](#string)|The [profile](#profiles) name that references a named type profile to be imported. An import statement must include either a url or a profile, but not both.|
+|repository|conditional|[string](#string)|The optional symbolic name of the [repository definition](#repository-definitions) where the imported file can be found as a string. The repository name can only be used when a url is specified.|
+|namespace|no|[string](#string)|The optional name of the [namespace](#namespaces) into which to import the type definitions from the imported template or profile.|
 |description|no|[string](#string)|Declares a [description](#description) for the import definition.|
-|metadata|no|map of YAML values|Defines a section used to declare additional [metadata](#metadata) information about the import definition.|
+|metadata|no|[map](#map) of YAML values|Defines a section used to declare additional [metadata](#metadata) information about the import definition.|
 
 These keynames can be used to import individual TOSCA files using the
 following grammar:
@@ -2344,15 +2344,15 @@ template:
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 |description|no|[string](#string)|The optional [description](#description) for the service template.|
-|metadata|no|map of YAML values|Defines a section used to declare additional [metadata](#metadata) information about this service template.|
-|[inputs](#input-parameters)|no|map of parameter definitions|An optional map of input parameters (i.e., as parameter definitions) for the service template.|
-|[node_templates](#node-template)|yes|map of node templates|A mandatory map of node template definitions for the service template.|
-|[relationship_templates](#relationship-template)|no|map of relationship templates|An optional map of relationship templates for the service template.|
-|[groups](#group-definitions)|no|map of group definitions|An optional map of Group definitions whose members are node templates defined within this same service template.|
-|[workflows](#workflow-definitions)|no|map of workflow definitions|An optional map of workflow definitions for the service template.|
-|[policies](#policy-definitions)|no|[list](#list) of policy definitions|An optional list of policy definitions for the service template.|
-|[outputs](#output-parameters)|no|map of parameter definitions|An optional map of output parameters (i.e., as parameter definitions) for the service template.|
-|[substitution_mappings](#substitution-mapping)|no|substitution_mapping|An optional declaration that exports the service template as an implementation of a Node type. This also includes the mappings between the external node type's capabilities and requirements to existing implementations of those capabilities and requirements on node templates declared within the service template.|
+|metadata|no|[map](#map) of YAML values|Defines a section used to declare additional [metadata](#metadata) information about this service template.|
+|inputs|no|[map](#map) of [parameter definitions](#input-parameters)|An optional map of input parameters (i.e., as parameter definitions) for the service template.|
+|node_templates|yes|[map](#map) of [node templates](#node-template)|A mandatory map of node template definitions for the service template.|
+|relationship_templates|no|[map](#map) of [relationship templates](#relationship-template)|An optional map of relationship templates for the service template.|
+|groups|no|[map](#map) of [group definitions](#group-definitions)|An optional map of Group definitions whose members are node templates defined within this same service template.|
+|workflows|no|[map](#map) of [workflow definitions](#workflow-definitions)|An optional map of workflow definitions for the service template.|
+|policies|no|[list](#list) of [policy definitions](#policy-definitions)|An optional list of policy definitions for the service template.|
+|outputs|no|[map](#map) of [parameter definitions](#output-parameters)|An optional map of output parameters (i.e., as parameter definitions) for the service template.|
+|substitution_mappings|no|[substitution_mapping](#substitution-mapping)|An optional declaration that exports the service template as an implementation of a Node type. This also includes the mappings between the external node type's capabilities and requirements to existing implementations of those capabilities and requirements on node templates declared within the service template.|
 
 The overall grammar of the service_template section is shown
 below. Detailed grammar definitions are provided in subsequent
@@ -2648,12 +2648,12 @@ node type definition has the following recognized keynames:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[properties](#property-definition)|no|map of property definitions|An optional map of property definitions for the node type.|
-|[attributes](#attribute-definition)|no|map of attribute definitions|An optional map of attribute definitions for the node type.|
-|[capabilities](#capability-definition)|no|map of capability definitions|An optional map of capability definitions for the node type.|
-|[requirements](#requirement-definition)|no|[list](#list) of requirement definitions|An optional list of requirement definitions for the node type.|
-|[interfaces](#interface-definition)|no|map of interface definitions|An optional map of interface definitions supported by the node type.|
-|[artifacts](#artifact-definition)|no|map of artifact definitions|An optional map of artifact definitions for the node type.|
+|properties|no|[map](#map) of [property definitions](#property-definition)|An optional map of property definitions for the node type.|
+|attributes|no|[map](#map) of [attribute definitions](#attribute-definition)|An optional map of attribute definitions for the node type.|
+|capabilities|no|[map](#map) of [capability definitions](#capability-definition)|An optional map of capability definitions for the node type.|
+|requirements|no|[list](#list) of [requirement definitions](#requirement-definition)|An optional list of requirement definitions for the node type.|
+|interfaces|no|[map](#map) of [interface definitions](#interface-definition)|An optional map of interface definitions supported by the node type.|
+|artifacts|no|[map](#map) of [artifact definitions](#artifact-definition)|An optional map of artifact definitions for the node type.|
 
 These keynames can be used according to the following grammar:
 ```yaml
@@ -2774,17 +2774,17 @@ template definition:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[type](#node-types)|yes|[string](#string)|The mandatory name of the node type on which the node template is based.|
+|type|yes|[string](#string)|The mandatory name of the [node type](#node-types) on which the node template is based.|
 |description|no|[string](#string)|An optional [description](#description) for the node template.|
-|metadata|no|map of string|Defines a section used to declare additional [metadata](#metadata) information. |
-|directives|no|[list](#list) of [string](#string)|An optional list of directive values to provide processing instructions to orchestrators and tooling.|
-|[properties](#property-assignment)|no|map of property assignments|An optional map of property value assignments for the node template.|
-|[attributes](#attribute-assignment)|no|map of attribute assignments|An optional map of attribute value assignments for the node template.|
-|[requirements](#requirement-assignment)|no|[list](#list) of requirement assignments|An optional list of requirement assignments for the node template.|
-|[capabilities](#capabilities-assignment)|no|[map](#map) of capability assignments|An optional map of capability assignments for the node template.|
-|[interfaces](#interface-assignment)|no|[map](#map) of interface assignments|An optional map of interface assignments for the node template.|
-|[artifacts](#artifact-definition)|no|[map](#map) of  artifact definitions|An optional map of artifact definitions for the node template.|
-|[count](#specifying-number-of-node-representations)|no|non-negative integer|An optional keyname that specifies how many node representations must be created from this node template. If not defined, the assumed count value is 1.|
+|metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
+|directives|no|[list](#list) of [string](#string)|An optional list of [directive](#node-template-directives) values to provide processing instructions to orchestrators and tooling.|
+|properties|no|[map](#map) of [property assignments](#property-assignment)|An optional map of property value assignments for the node template.|
+|attributes|no|[map](#map) of [attribute assignments](#attribute-assignment)|An optional map of attribute value assignments for the node template.|
+|requirements|no|[list](#list) of [requirement assignments](#requirement-assignment)|An optional list of requirement assignments for the node template.|
+|capabilities|no|[map](#map) of [capability assignments](#capabilities-assignment)|An optional map of capability assignments for the node template.|
+|interfaces|no|[map](#map) of [interface assignments](#interface-assignment)|An optional map of interface assignments for the node template.|
+|artifacts|no|[map](#map) of [artifact definitions](#artifact-definition)|An optional map of artifact definitions for the node template.|
+|count|no|non-negative integer|An optional keyname that specifies how many [node representations](#specifying-number-of-node-representations) must be created from this node template. If not defined, the assumed count value is 1.|
 |node_filter|no|[node filter](#node-filter-definition)|The optional filter definition that TOSCA orchestrators will use to select an already existing node if this node template is marked with the `select` directive.|
 |copy|no|[string](#string)|The optional (symbolic) name of another node template from which to copy all keynames and values into this node template.|
 
@@ -2880,7 +2880,8 @@ node_templates:
         operations:
           configure: scripts/my_own_configure.sh
 ```
-### 7.2.1 Node template directives
+### 7.2.1 Node template directives<a name=node-template-directives</a>
+
 
 As described in the section above, a node template supports the following 3 directives 
 used by the TOSCA resolver to populate nodes in the representation graph.
@@ -2939,12 +2940,12 @@ relationship type definition has the following recognized keynames:
 
 |Keyname|Mandatory|Definition/Type|Description|
 | :---- | :------ | :---- | :------ |
-|[properties](#property-definition)|no|[map](#map) of property definitions|An optional map of property definitions for the relationship type.|
-|[attributes](#attribute-definition)|no|[map](#map) of attribute definitions|An optional map of attribute definitions for the relationship type.|
-|[interfaces](#interface-definition)|no|[map](#map) of interface definitions|An optional map of interface definitions supported by the relationship type.|
-|valid_capability_types|no|[list](#list) of [string](#string)|An optional list of one or more names of capability types that are valid targets for this relationship. If undefined, all capability types are valid.|
-|valid_target_node_types|no|[list](#list) of [string](#string)|An optional list of one or more names of node types that are valid targets for this relationship. If undefined, all node types are valid targets.|
-|valid_source_node_types|no|[list](#list) of [string](#string)|An optional list of one or more names of node types that are valid sources for this relationship. If undefined, all node types are valid sources.|
+|properties|no|[map](#map) of [property definition](#property-definition)|An optional map of property definitions for the relationship type.|
+|attributes|no|[map](#map) of [attribute definitions](#attribute-definition)|An optional map of attribute definitions for the relationship type.|
+|interfaces|no|[map](#map) of [interface definitions](#interface-definition)|An optional map of interface definitions supported by the relationship type.|
+|valid_capability_types|no|[list](#list) of [string](#string)|An optional list of one or more names of [capability types](#capability-types) that are valid targets for this relationship. If undefined, all capability types are valid.|
+|valid_target_node_types|no|[list](#list) of [string](#string)|An optional list of one or more names of [node types](#node_types) that are valid targets for this relationship. If undefined, all node types are valid targets.|
+|valid_source_node_types|no|[list](#list) of [string](#string)|An optional list of one or more names of [node types](#node_types) that are valid sources for this relationship. If undefined, all node types are valid sources.|
 
 These keynames can be used according to the following grammar:
 ```yaml
@@ -3057,12 +3058,12 @@ relationship template definition:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[type](#relationship-types)|yes|[string](#string)|The mandatory name of the relationship type on which the relationship template is based.|
+|type|yes|[string](#string)|The mandatory name of the [relationship type](#relationship-types) on which the relationship template is based.|
 |description|no|[string](#string)|An optional [description](#description) for the relationship template.|
-|metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
-|[properties](#property-definition)|no|[map](#map) of property assignments|An optional map of property assignments for the relationship template.|
-|[attributes](#attribute-definition)|no|[map](#map) of attribute assignments|An optional map of attribute assignments for the relationship template.|
-|[interfaces](#interface-assignment)|no|[map](#map) of interface assignments|An optional map of interface assignments for the relationship template.|
+|metadata|no|[map](#map) of [string](#string)|Defines a section used to declare additional [metadata](#metadata) information. |
+|properties|no|[map](#map) of [property assignments](#property-definition)|An optional map of property assignments for the relationship template.|
+|attributes|no|[map](#map) of [attribute assignments](#attribute-definition)|An optional map of attribute assignments for the relationship template.|
+|interfaces|no|[map](#map) of [interface assignments](#interface-assignment)|An optional map of interface assignments for the relationship template.|
 |copy|no|[string](#string)|The optional (symbolic) name of another relationship template from which to copy all keynames and values into this relationship template.|
 
 These keynames can be used according to the following grammar:
@@ -3143,8 +3144,8 @@ capability type definition has the following recognized keynames:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[properties](#property-definition)|no|[map](#map) of property definitions|An optional map of property definitions for the capability type.|
-|[attributes](#attribute-definition)|no|[map](#map) of attribute definitions|An optional map of attribute definitions for the capability type.|
+|properties|no|[map](#map) of [property definitions](#property-definition)|An optional map of property definitions for the capability type.|
+|attributes|no|[map](#map) of [attribute definitions](#attribute-definition)|An optional map of attribute definitions for the capability type.|
 |valid_source_node_types|no|[list](#list) of [string](#string)|An optional list of one or more valid names of node types that are supported as valid sources of any relationship established to the declared capability type. If undefined, all node types are valid sources.|
 |valid_relationship_types|no|[list](#list) of [string](#string)|An optional list of one or more valid names of relationship types that are supported as valid types of any relationship established to the declared capability type. If undefined, all relationship types are valid.|
 
@@ -3240,8 +3241,8 @@ definition:
 |[type](#capability-type)|yes|[string](#string)|The mandatory name of the capability type on which this capability definition is based.|
 |description|no|[string](#string)|The optional [description](#description) of the Capability definition.|
 |metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
-|[properties](#property-definition)|no|[map](#map) of property refinements|An optional map of property refinements for the capability definition. The referred properties must have been defined in the capability type definition referred by the type keyword. New properties may not be added.|
-|[attributes](#attribute-definition)|no|[map](#map) of attribute refinements|An optional map of attribute refinements for the capability definition. The referred attributes must have been defined in the capability type definition referred by the type keyword. New attributes may not be added.|
+|properties|no|[map](#map) of [property refinements](#property-definition)|An optional map of property refinements for the capability definition. The referred properties must have been defined in the capability type definition referred by the type keyword. New properties may not be added.|
+|attributes|no|[map](#map) of [attribute refinements](#attribute-definition)|An optional map of attribute refinements for the capability definition. The referred attributes must have been defined in the capability type definition referred by the type keyword. New attributes may not be added.|
 |valid_source_node_types|no|[list](#list) of [string](#string)|An optional list of one or more valid names of node types that are supported as valid sources of any relationship established to the declared capability type. If undefined, all node types are valid sources. If valid_source_node_types is defined in the capability type, each element in this list must either be or derived from an element in the list defined in the type.|
 |valid_relationship_types|no|[list](#list) of [string](#string)|An optional list of one or more valid names of relationship types that are supported as valid types of any relationship established to the declared capability type. If undefined, all relationship types are valid. If valid_relationship_types is defined in the capability type, each element in this list must either be or derived from an element in the list defined in the type.|
 
@@ -3364,7 +3365,7 @@ assignment:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[properties](#property-definition)|no|[map](#map) of  property assignments|An optional map of property assignments for the capability definition.|
+|properties|no|[map](#map) of  [property assignments](#property-definition)|An optional map of property assignments for the capability definition.|
 |[attributes](#attribute-definition)|no|[map](#map) of attribute assignments|An optional map of attribute assignments for the capability definition.|
 |directives|no|An optional list of directive values to provide processing instructions to orchestrators and tooling.|
 
@@ -3459,8 +3460,8 @@ support the following keynames:
 |[type](#relationship-types)|yes|[string](#string)|The mandatory keyname used to provide the name of the relationship type used for the relationship.|
 |description|no|[string](#string)|The optional [description](#description) of the relationship definition.|
 |metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
-|[properties](#property-definition)|no|[map](#map) of property refinements|An optional map of property refinements for the relationship definition. The referred properties must have been defined in the relationship type definition referred by the type keyword. New properties may not be added.|
-|[attributes](#attribute-definition)|no|[map](#map) of attribute refinements|An optional map of attribute refinements for the relationship definition. The referred attributes must have been defined in the relationship type definition referred by the type keyword. New attributes may not be added.|
+|properties|no|[map](#map) of [property refinements](#property-definition)|An optional map of property refinements for the relationship definition. The referred properties must have been defined in the relationship type definition referred by the type keyword. New properties may not be added.|
+|[attributes](#attribute-definition)|no|[map](#map) of [attribute refinements](#attribute-definition)|An optional map of attribute refinements for the relationship definition. The referred attributes must have been defined in the relationship type definition referred by the type keyword. New attributes may not be added.|
 |[interfaces](#interface-definition)|no|[map](#map) of interface refinements|The optional keyname used to define interface refinements for interfaces defined by the relationship type.|
 
 The keynames supported by requirement definitions and relationship
@@ -3642,7 +3643,7 @@ support the following keynames:
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 |[type](#relationship-types)|no|[string](#string)|The optional keyname used to provide the name of the relationship type for the requirement assignment’s relationship.|
-|[properties](#property-assignment)|no|[map](#map) of property assignments|An optional map of property assignments for the relationship.|
+|properties|no|[map](#map) of [property assignments](#property-definition)|An optional map of property assignments for the relationship.|
 |[attributes](#attribute-assignment)|no|[map](#map) of attribute assignments|An optional map of attribute assignments for the relationship.|
 |[interfaces](#interface-assignment)|no|[map](#map) of interface assignments|An optional map of interface assignments for the corresponding interface definitions in the relationship type.|
 
@@ -4905,7 +4906,7 @@ data type definition has the following recognized keynames:
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 |validation|no|[validation clause](#validation-clause)|The optional validation clause that must evaluate to True for values of this data type to be valid.|
-|[properties](#property-definition)|no|[map](#map) of property definitions|The optional map property definitions that comprise the schema for a complex data type in TOSCA. |
+|properties|no|[map](#map) of (property definitions)(#property-definition)|The optional map property definitions that comprise the schema for a complex data type in TOSCA. |
 |key_schema|conditional|schema definition|For data types that derive from the TOSCA map data type, the optional schema definition for the keys used to identify entries in properties of this data type. If not specified, the key_schema defaults to string. If present, the key_schema must derive from string. For data types that do not derive from the TOSCA map data type, the key_schema is not allowed.|
 |entry_schema|conditional|schema definition|For data types that derive from the TOSCA map or list data types, the mandatory schema definition for the entries in properties of this data type. For data types that do not derive from the TOSCA list or map data type, the entry_schema is not allowed.|
 
@@ -7164,7 +7165,7 @@ interface type definition has the following recognized keynames:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[inputs](#input-parameters)|no|[map](#map) of parameter definitions|The optional map of input parameter definitions available to all operations defined for this interface.|
+|inputs|no|[map](#map) of [parameter definitions](#input-parameters)|The optional map of input parameter definitions available to all operations defined for this interface.|
 |[operations](#operation-definition)|no|[map](#map) of operation definitions|The optional map of operations defined for this interface.|
 |[notifications](#notification-definition)|no|[map](#map) of notification definitions|The optional map of notifications defined for this interface.|
 
@@ -7246,7 +7247,7 @@ definition:
 |[type](#interface-types)|yes|[string](#string)|The mandatory name of the interface type on which this interface definition is based.|
 |description|no|[string](#string)|The optional [description](#description) for this interface definition.|
 |metadata|no|[map](#map) of metadata|Defines additional [metadata](#metadata) information.|
-|[inputs](#input-parameters)|no|[map](#map) of parameter definitions and refinements|The optional map of input parameter refinements and new input parameter definitions available to all operations defined for this interface (the input parameters to be refined have been defined in the interface type definition).|
+|inputs|no|[map](#map) of [parameter definitions and refinements](#input-parameters)|The optional map of input parameter refinements and new input parameter definitions available to all operations defined for this interface (the input parameters to be refined have been defined in the interface type definition).|
 |[operations](#operation-definition)|no|[map](#map) of operation refinements|The optional map of operations refinements for this interface. The referred operations must have been defined in the interface type definition.|
 |[notifications](#notification-definition)|no|[map](#map) of notification refinements|The optional map of notifications refinements for this interface. The referred operations must have been defined in the interface type definition.|
 
@@ -7328,7 +7329,7 @@ assignment:
 
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
-|[inputs](#input-parameters)|no|[map](#map) of parameter value assignments|The optional map of input parameter assignments. Template authors MAY provide parameter assignments for interface inputs that are not defined in their corresponding interface type.|
+|inputs|no|[map](#map) of [parameter value assignments](#input-parameters)|The optional map of input parameter assignments. Template authors MAY provide parameter assignments for interface inputs that are not defined in their corresponding interface type.|
 |[operations](#operation-definition)|no|[map](#map) of operation assignments|The optional map of operations assignments specified for this interface.|
 |[notifications](#notification-definition)|no|[map](#map) of notification assignments|The optional map of notifications assignments specified for this interface.|
 
@@ -7381,8 +7382,8 @@ definition (including definition refinement)
 | :---- | :------ | :---- | :------ |
 |description|no|[string](#string)|The optional [description](#description) string for the associated operation.|
 |implementation|no|operation implementation definition|The optional definition of the operation implementation. May not be used in an interface type definition (i.e. where an operation is initially defined), but only during refinements. |
-|[inputs](#input-parameters)|no|[map](#map) of parameter definitions|The optional map of parameter definitions for operation input values.|
-|[outputs](#output-parameters)|no|[map](#map) of parameter definitions|The optional map of parameter definitions for operation output values. Only as part of node and relationship type definitions, the output definitions may include mappings onto attributes of the node or relationship type that contains the definition.|
+|inputs|no|[map](#map) of [parameter definitions](#input-parameters)|The optional map of parameter definitions for operation input values.|
+|outputs|no|[map](#map) of [parameter definitions](#output-parameters)|The optional map of parameter definitions for operation output values. Only as part of node and relationship type definitions, the output definitions may include mappings onto attributes of the node or relationship type that contains the definition.|
 
 Operation definitions have the following grammar:
 ```yaml
@@ -7522,8 +7523,8 @@ assignment:
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 implementation|no|operation implementation definition|The optional definition of the operation implementation. Overrides implementation provided at operation definition.|
-|[inputs](#input-parameters)|no|[map](#map) of parameter value assignments|The optional map of parameter value assignments for assigning values to operation inputs. |
-|[outputs](#output-parameters)|no|[map](#map) of parameter mapping assignments|The optional map of parameter mapping assignments that specify how operation outputs are mapped onto attributes of the node or relationship that contains the operation definition. |
+|inputs|no|[map](#map) of [parameter value assignments](#input-parameters)|The optional map of parameter value assignments for assigning values to operation inputs. |
+|outputs|no|[map](#map) of [parameter mapping assignments](#output-parameters)|The optional map of parameter mapping assignments that specify how operation outputs are mapped onto attributes of the node or relationship that contains the operation definition. |
 
 Operation assignments have the following grammar:
 
@@ -7622,8 +7623,8 @@ notification definition:
 | :---- | :------ | :---- | :------ |
 |description|no|[string](#string)|The optional [description](#description) string for the associated notification.|
 |implementation|no|notification implementation definition|The optional definition of the notification implementation.|
-|[inputs](#input-parameters)|no|[map](#map) of parameter definitions|The optional map of parameter definitions for notification input values.|
-|[outputs](#output-parameters)|no|[map](#map) of parameter definitions|The optional map of parameter definitions that specify notification output values.  Only as part of node and relationship type definitions, the output definitions may include their mappings onto attributes of the node type or relationship type that contains the definition. |
+|inputs|no|[map](#map) of [parameter definitions](#input-parameters)|The optional map of parameter definitions for notification input values.|
+|outputs|no|[map](#map) of [parameter definitions](#output-parameters)|The optional map of parameter definitions that specify notification output values.  Only as part of node and relationship type definitions, the output definitions may include their mappings onto attributes of the node type or relationship type that contains the definition. |
 
 Notification definitions have the following grammar:
 
@@ -7730,8 +7731,8 @@ notification assignment:
 |Keyname|Mandatory|Type|Description|
 | :---- | :------ | :---- | :------ |
 |implementation|no|notification implementation definition|The optional definition of the notification implementation. Overrides implementation provided at notification definition.|
-|[inputs](#input-parameters)|no|[map](#map) of parameter value assignments|The optional map of parameter value assignments for assigning values to notification inputs. |
-|[outputs](#output-parameters)|no|[map](#map) of parameter mapping assignments|The optional map of parameter mapping assignments that specify how notification outputs values are mapped onto attributes of the node or relationship type that contains the notification definition.|
+|inputs|no|[map](#map) of [parameter value assignments](#input-parameters)|The optional map of parameter value assignments for assigning values to notification inputs. |
+|outputs|no|[map](#map) of [parameter mapping assignments](#output-parameters)|The optional map of parameter mapping assignments that specify how notification outputs values are mapped onto attributes of the node or relationship type that contains the notification definition.|
 
 Notification assignments have the following grammar:
 ```yaml
@@ -7866,7 +7867,7 @@ artifact type definition has the following recognized keynames:
 | :---- | :------ | :---- | :------ |
 |mime_type|no|[string](#string)|The optional mime type property for the artifact type.|
 |file_ext|no|[list](#list) of [string](#string)|The optional file extension property for the artifact type.|
-|[properties](#property-definition)|no|[map](#map) of property definitions|An optional map of property definitions for the artifact type.|
+|properties|no|[map](#map) of (property definitions)(#property-definition)|An optional map of property definitions for the artifact type.|
 
 ```yaml
 <artifact_type_name>:
@@ -7963,7 +7964,7 @@ definition:
 |artifact_version|no|[string](#string)|The version of this artifact. One use of this artifact_version is to declare the particular version of this artifact type, in addition to its mime_type (that is declared in the artifact type definition). Together with the mime_type it may be used to select a particular artifact processor for this artifact. For example, a python interpreter that can interpret python version 2.7.0.|
 |checksum|no|[string](#string)|The checksum used to validate the integrity of the artifact.|
 |checksum_algorithm|no|[string](#string)|Algorithm used to calculate the artifact checksum (e.g. MD5, SHA [Ref]). Shall be specified if checksum is specified for an artifact.|
-|[properties](#property-definition)|no|[map](#map) of property assignments|The optional map of property assignments associated with the artifact.|
+|properties|no|[map](#map) of [property assignments](#property-definition)|The optional map of property assignments associated with the artifact.|
 
 Artifact definitions have the following grammar:
 
@@ -8056,11 +8057,11 @@ definition:
 | ----- | ------- | ----- | ------- |
 |description|no|[string](#string)|The optional [description](#description) for the workflow definition.|
 |metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
-|[inputs](#input-parameters)|no|[map](#map) of parameter definitions|The optional map of input parameter definitions.|
+|inputs|no|[map](#map) of [parameter definitions](#input-parameters)|The optional map of input parameter definitions.|
 |precondition|no|condition clause|Condition clause that must evaluate to true before the workflow can be processed.|
 |steps|no|[map](#map) of step definitions|An optional map of valid imperative workflow step definitions.|
 |implementation|no|operation implementation definition|The optional definition of an external workflow definition. This keyname is mutually exclusive with the steps keyname above.|
-|[outputs](#output-parameters)|no|[map](#map) of attribute mappings|The optional map of attribute mappings that specify workflow  output values and their mappings onto attributes of a node or relationship defined in the service.|
+|outputs|no|[map](#map) of [attribute mappings](#output-parameters)|The optional map of attribute mappings that specify workflow  output values and their mappings onto attributes of a node or relationship defined in the service.|
 
 Imperative workflow definitions have the following grammar:
 ```yaml
@@ -8188,7 +8189,7 @@ definition.
 | ----- | ------- | ----- | ------- |
 |delegate|yes|string or empty  (see grammar below)|Defines the name of the delegate workflow and optional input assignments. This activity requires the target to be provided by the orchestrator (no-op node or relationship).|
 |workflow|no|[string](#string)|The name of the delegate workflow. Mandatory in the extended notation.|
-|[inputs](#input-parameters)|no|[map](#map) of parameter assignments|The optional map of input parameter assignments for the delegate workflow.|
+|inputs|no|[map](#map) of [parameter assignments](#input-parameters)|The optional map of input parameter assignments for the delegate workflow.|
 
 A delegate activity definition has the following grammar.
 
@@ -8246,7 +8247,7 @@ activity definition.
 | ----- | ------- | ----- | ------- |
 |call_operation|yes|string or empty (see grammar below)|Defines the opration call. The operation name uses the \<interface_name\>.\<operation_name\> notation. Optionally, assignments for the operation inputs can also be provided. If provided, they will override for this operation call the operation inputs assignment in the node template.|
 |operation|no|[string](#string)|The name of the operation to call, using the \<interface_name\>.\<operation_name\> notation.  Mandatory in the extended notation.|
-|[inputs](#input-parameters)|no|[map](#map) of parameter assignments|The optional map of input parameter assignments for the called operation. Any provided input assignments will override the operation input assignment in the target node template for this operation call.|
+|inputs|no|[map](#map) of [parameter assignments](#input-parameters)|The optional map of input parameter assignments for the called operation. Any provided input assignments will override the operation input assignment in the target node template for this operation call.|
 
 A call operation activity definition has the following grammar.
 ```yaml
@@ -8286,7 +8287,7 @@ activity definition.
 | ----- | ------- | ----- | ------- |
 |inline|yes|string or empty (see grammar below)|The definition includes the name of a workflow to be inlined and optional workflow input assignments.|
 |workflow|no|[string](#string)|The name of the inlined workflow. Mandatory in the extended notation.|
-|[inputs](#input-parameters)|no|[map](#map) of parameter assignments|The optional map of input parameter assignments for the inlined workflow.|
+|inputs|no|[map](#map) of [parameter assignments](#input-parameters)|The optional map of input parameter assignments for the inlined workflow.|
 
 An inline workflow activity definition has the following grammar.
 ```yaml
@@ -10112,8 +10113,8 @@ group type definition has the following recognized keynames:
 
 |Keyname|Mandatory|Type|Description|
 | ----- | ------- | ----- | ------- |
-|[properties](#property-definition)|no|[map](#map) of property definitions|An optional map of property definitions for the group type.|
-|[attributes](#attribute-definition)|no|[map](#map) of attribute definitions|An optional map of attribute definitions for the group type.|
+|properties|no|[map](#map) of (property definitions)(#property-definition)|An optional map of property definitions for the group type.|
+|attributes|no|[map](#map) of [attribute definitions](#attribute-definition)|An optional map of attribute definitions for the group type.|
 |members|no|[list](#list) of [string](#string)|An optional list of one or more names of node types that are valid (allowed) as members of the group type.|
 
 Group types have the following grammar:
@@ -10190,7 +10191,7 @@ TOSCA group definition:
 |[type](#group-types)|yes|[string](#string)|The mandatory name of the group type the group definition is based upon.|
 |description|no|[string](#string)|The optional [description](#description) for the group definition.|
 |metadata|no|[map](#map) of YAML data|Defines a section used to declare additional [metadata](#metadata) information. |
-|[properties](#property-definition)|no|[map](#map) of property assignments|An optional map of property value assignments for the group definition.|
+|properties|no|[map](#map) of [property assignments](#property-definition)|An optional map of property value assignments for the group definition.|
 |[attributes](#attribute-definition)|no|[map](#map) of attribute assignments|An optional map of attribute value assignments for the group definition.|
 |members|no|[list](#list) of [string](#string)|The optional list of one or more node template names that are members of this group definition.|
 
@@ -10254,7 +10255,7 @@ policy type definition has the following recognized keynames:
 
 |Keyname|Mandatory|Type|Description|
 | ----- | ------- | ----- | ------- |
-|[properties](#property-definition)|no|[map](#map) of property definitions|An optional map of property definitions for the policy type.|
+|properties|no|[map](#map) of (property definitions)(#property-definition)|An optional map of property definitions for the policy type.|
 |targets|no|[list](#list) of [string](#string)|An optional list of valid node types or group types the policy type can be applied to.|
 |[triggers](#trigger-definition)|no|[map](#map) of trigger definitions |An optional map of policy triggers for the policy type.|
 
@@ -10325,7 +10326,7 @@ definition:
 |[type](#policy-type)|yes|[string](#string)|The mandatory name of the policy type the policy definition is based upon.|
 |description|no|[string](#string)|The optional [description](#description) for the policy definition.|
 |metadata|no|[map](#map) of string|Defines a section used to declare additional [metadata](#metadata) information. |
-|[properties](#property-definition)|no|[map](#map) of property assignments|An optional map of property value assignments for the policy definition.|
+|properties|no|[map](#map) of [property assignments](#property-definition)|An optional map of property value assignments for the policy definition.|
 |targets|no|[list](#list) of [string](#string)|An optional list of valid node templates or Groups the Policy can be applied to.|
 |[triggers](#trigger-definition)|no|[map](#map) of trigger definitions|An optional map of trigger definitions to invoke when the policy is applied by an orchestrator against the associated TOSCA entity. These triggers apply in addition to the triggers defined in the policy type.|
 


### PR DESCRIPTION
Moved remaining links from col 1 to col 2 in grammar tables.
Corrected broken link in TOSCA Naming Conventions
Corrected formatting of one paragraph in  Scalar Units