### PR TITLE
Tag and extract examples

### DIFF
--- a/tosca_2_0/TOSCA-v2.0-csd07.md
+++ b/tosca_2_0/TOSCA-v2.0-csd07.md
@@ -188,11 +188,13 @@ Within this document we use monospace font sections to denote code snippets,
 primarily for TOSCA (YAML), but also for other textual file formats (e.g. CSAR
 meta files). For example:
 
+<!-- EDITOR_TAG{"type":"example","id":"s1","action":"start"} -->
 ```yaml
 MyMap:
   property1: value
   property2: [ value1, value2 ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s1","action":"end"} -->
 
 #### 1.2.1.2 Placeholders
 
@@ -1432,12 +1434,14 @@ map of keynames with values that can use all types supported by
 the [\[YAML-1.2\] chapter 10 recommended schemas](https://yaml.org/spec/1.2.2/#chapter-10-recommended-schemas)
 as follows:
 
+<!-- EDITOR_TAG{"type":"example","id":"s2","action":"start"} -->
 ```yaml
 metadata:
   <metadata_name_1>: <metadata_value_1>
   <metadata_name_2>: <metadata_value_2>
   ...
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s2","action":"end"} -->
 
 Specifically, the following YAML types can be used for metadata
 values: "!!map", "!!seq", "!!str", "!!null", "!!bool", "!!int", "!!float".
@@ -1445,12 +1449,14 @@ values: "!!map", "!!seq", "!!str", "!!null", "!!bool", "!!int", "!!float".
 The following shows an example that uses `metadata` to track revision
 status of a TOSCA file:
 
+<!-- EDITOR_TAG{"type":"example","id":"s3","action":"start"} -->
 ```yaml
 metadata: 
   creation-date: 2024-04-14
   date-updated: 2024-05-01
   status: developmental  
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s3","action":"end"} -->
 
 Data provided within metadata, wherever it appears, MAY be ignored by
 TOSCA Orchestrators and SHOULD NOT affect runtime behavior.
@@ -1461,29 +1467,36 @@ This optional keyname provides a means to include single or multiline
 descriptions within a TOSCA element as a *YAML string value*, as
 follows:
 
+<!-- EDITOR_TAG{"type":"example","id":"s4","action":"start"} -->
 ```yaml
 description: <description_string>
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s4","action":"end"} -->
 
 Standard YAML block and flow formats are supported for the description
 string. Simple descriptions are treated as a single literal that includes
 the entire contents of the line that immediately follows the description
 keyname:
 
+<!-- EDITOR_TAG{"type":"example","id":"s5","action":"start"} -->
 ```yaml
 description: This is an example of a single line description (no folding). 
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s5","action":"end"} -->
 
 The following shows a multiline flow example:
 
+<!-- EDITOR_TAG{"type":"example","id":"s6","action":"start"} -->
 ```yaml
 description: "A multiline description 
 using a quoted string"
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s6","action":"end"} -->
 
 The YAML *folded* format may also be used for multiline descriptions,
 which *folds* line breaks as space characters:
 
+<!-- EDITOR_TAG{"type":"example","id":"s7","action":"start"} -->
 ```yaml
 description: >
   This is an example of a multi-line description using YAML. It permits for line        
@@ -1492,6 +1505,7 @@ description: >
   if needed.  However, (multiple) line breaks are folded into a single space   
   character when processed into a single string value.
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s7","action":"end"} -->
 
 # 6 TOSCA File Definition <a name=tosca-file-def></a>
 
@@ -1555,9 +1569,11 @@ keynames and associated grammars used in a TOSCA file definition.
 The mandatory `tosca_definitions_version` keyname provides a means to
 specify the TOSCA version used within the TOSCA file as follows:
 
+<!-- EDITOR_TAG{"type":"example","id":"s8","action":"start"} -->
 ```yaml
 tosca_definitions_version: <tosca_version> 
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s8","action":"end"} -->
 
 It is an indicator for the version of the TOSCA grammar that MUST be
 used to parse the remainder of the TOSCA file. TOSCA uses the
@@ -1576,9 +1592,11 @@ The version for this specification is `tosca_2_0`. The following
 shows an example `tosca_definitions_version` in a TOSCA file created
 using the TOSCA Version 2.0 specification:
 
+<!-- EDITOR_TAG{"type":"example","id":"s9","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s9","action":"end"} -->
 
 Note that it is not mandatory for TOSCA Version 2.0 implementations to
 support older versions of the TOSCA specifications.
@@ -1754,11 +1772,13 @@ artifact_types:
 
 The following code snippet shows an example artifact type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s10","action":"start"} -->
 ```yaml
 artifact_types:
   MyFile:
     derived_from: foobar:File
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s10","action":"end"} -->
 
 A detailed description of the artifact type definition grammar is
 provided in the [Artifacts chapter](#artifacts).
@@ -1820,6 +1840,7 @@ capability_types:
 
 The following code snippet shows example capability type definitions:
 
+<!-- EDITOR_TAG{"type":"example","id":"s11","action":"start"} -->
 ```yaml
 capability_types:
   MyGenericFeature:
@@ -1836,6 +1857,7 @@ capability_types:
     properties:
       # more details ...
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s11","action":"end"} -->
 
 A detailed description of the capability type definition grammar is
 provided in the [Capability Type section](#capability-type).
@@ -1854,6 +1876,7 @@ interface_types:
 
 The following code snippet shows an example interface type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s12","action":"start"} -->
 ```yaml
 interface_types:
   Signal:
@@ -1863,6 +1886,7 @@ interface_types:
       signal-end-receive:
         description: Operation to signal end of some message processed.
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s12","action":"end"} -->
 
 A detailed description of the interface type definition grammar is
 provided in the [Interface Type section](#interface-type).
@@ -1881,6 +1905,7 @@ relationship_types:
 
 The following code snippet shows example relationship type definitions:
 
+<!-- EDITOR_TAG{"type":"example","id":"s13","action":"start"} -->
 ```yaml
 relationship_types:
   HostedOn:
@@ -1896,6 +1921,7 @@ relationship_types:
     properties:
       # more details ...
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s13","action":"end"} -->
 
 A detailed description of the relationship type definition grammar is
 provided in the [Interface Type section](#relationship-type).
@@ -1914,6 +1940,7 @@ node_types:
 
 The following code snippet shows example node type definitions:
 
+<!-- EDITOR_TAG{"type":"example","id":"s14","action":"start"} -->
 ```yaml
 node_types:
   Database:
@@ -1933,6 +1960,7 @@ node_types:
     capabilities:
       TransactSQL
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s14","action":"end"} -->
 
 A detailed description of the node type definition grammar is
 provided in the [Node Type section](#node-type).
@@ -1951,11 +1979,13 @@ group_types:
 
 The following code snippet shows an example group type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s15","action":"start"} -->
 ```yaml
 group_types:
   MyScalingGroup:
     derived_from: foobar:MyGroup
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s15","action":"end"} -->
 
 A detailed description of the group type definition grammar is
 provided in the [Group Type section](#group-type).
@@ -1974,11 +2004,13 @@ policy_types:
 
 The following code snippet shows an example policy type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s16","action":"start"} -->
 ```yaml
 policy_types:
   MyScalingPolicy:
     derived_from: foobar:Scaling
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s16","action":"end"} -->
 
 A detailed description of the policy type definition grammar is
 provided in the [Policy Type section](#policy-type).
@@ -2044,6 +2076,7 @@ also use a single-line grammar as follows:
 The following example show repository definitions using both
 multiline as well as single-line grammars.
 
+<!-- EDITOR_TAG{"type":"example","id":"s17","action":"start"} -->
 ```yaml
 repositories:
   my-project:
@@ -2052,6 +2085,7 @@ repositories:
 
   external-repo: https://foo.bar
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s17","action":"end"} -->
 
 ## 6.6 Function Definitions <a name=function-definitions></a>
 
@@ -2069,6 +2103,7 @@ functions:
 
 The following example shows the definition of a square root function:
 
+<!-- EDITOR_TAG{"type":"example","id":"s18","action":"start"} -->
 ```yaml
 functions:
   sqrt:
@@ -2090,6 +2125,7 @@ functions:
       the argument is either integer or float and the function
       returns the square root as a float.
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s18","action":"end"} -->
 
 ## 6.7 Profiles <a name=profiles></a>
 
@@ -2139,15 +2175,19 @@ notation with version as a best-practice convention. For example, the
 following profile statement is used to define Version 2.0 of a set of 
 definitions suitable for describing cloud computing in an example company:
 
+<!-- EDITOR_TAG{"type":"example","id":"s19","action":"start"} -->
 ```yaml
 profile: com.example.tosca_profiles.cloud_computing:2.0 
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s19","action":"end"} -->
 
 The following defines a domain-specific profile for Kubernetes:
 
+<!-- EDITOR_TAG{"type":"example","id":"s20","action":"start"} -->
 ```yaml
 profile: io.kubernetes:1.30
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s20","action":"end"} -->
 
 TOSCA parsers MUST process profile definitions according to the
 following rules:
@@ -2211,6 +2251,7 @@ Assume a profile designer creates version 1 of a base profile that
 defines (among other things) a "Host" capability type and a
 corresponding "HostedOn" relationship type as follows:
 
+<!-- EDITOR_TAG{"type":"example","id":"s21","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 profile: org.base:v1
@@ -2223,6 +2264,7 @@ relationship_types:
   HostedOn:
     valid_capability_types: [ Host ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s21","action":"end"} -->
 
 Now let's assume a different profile designer creates a
 platform-specific profile that defines (among other things) a
@@ -2231,6 +2273,7 @@ type "Host". Since the "Host" capability is defined in the
 "org.base:v1" profile, that profile must be imported as shown in the
 snippet below:
 
+<!-- EDITOR_TAG{"type":"example","id":"s22","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 profile: org.platform
@@ -2245,6 +2288,7 @@ node_types:
       host:
         type: p1:Host
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s22","action":"end"} -->
 
 At some later point in time, the original profile designer updates the
 "org.base" profile to Version 2. The updated version of this profile
@@ -2252,6 +2296,7 @@ just adds a "Credential" data type (in addition to defining the
 "Host" capability type and the "HostedOn" relationship type), as
 follows:
 
+<!-- EDITOR_TAG{"type":"example","id":"s23","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 profile: org.base:v2
@@ -2270,6 +2315,7 @@ data_types:
       key:
         type: string
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s23","action":"end"} -->
 
 Finally, let's assume a service designer creates a template for a
 service that is to be hosted on the platform defined in the
@@ -2278,6 +2324,7 @@ type that has a requirement for the platform's "Host" capability. It
 also has a credential property of type "Credential" as defined in
 "org.base:v2":
 
+<!-- EDITOR_TAG{"type":"example","id":"s24","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -2309,6 +2356,7 @@ service_template:
     platform:
       type: pl:Platform
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s24","action":"end"} -->
 
 This service template is invalid, since the "platform" node template
 does not define a capability of a type that is compatible with the
@@ -2477,43 +2525,52 @@ import the file referenced by `<file_uri>` as follows:
 The first example shows how to use an import definition import a
 well-known profile by name:
 
+<!-- EDITOR_TAG{"type":"example","id":"s25","action":"start"} -->
 ```yaml
 # Importing a profile
 imports:
 - profile: org.oasis-open.tosca.simple:2.0
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s25","action":"end"} -->
 
 The next example shows an import definition used to import a
 network-accessible resource using the https protocol:
 
+<!-- EDITOR_TAG{"type":"example","id":"s26","action":"start"} -->
 ```yaml
 # Absolute URL with scheme
 imports:
 - url: https://myorg.org/tosca/types/mytypes.yaml
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s26","action":"end"} -->
 
 The following shows an import definition used to import a TOSCA file
 located in the same repository as the importing file. The file to be
 imported is referenced using a path name that is relative to the
 location of the importing file. This example shows the short notation:
 
+<!-- EDITOR_TAG{"type":"example","id":"s27","action":"start"} -->
 ```yaml
 # Short notation supported
 imports:
 - ../types/mytypes.yaml 
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s27","action":"end"} -->
 
 The following shows the same example but using the long notation:
 
+<!-- EDITOR_TAG{"type":"example","id":"s28","action":"start"} -->
 ```yaml
 # Long notation
 imports:
 - url: ../types/mytypes.yaml
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s28","action":"end"} -->
 
 The following example mixes short-notation and
 long-notation import definitions:
 
+<!-- EDITOR_TAG{"type":"example","id":"s29","action":"start"} -->
 ```yaml
 # Short notation and long notation supported
 imports:
@@ -2522,26 +2579,31 @@ imports:
   repository: my-company-repo
   namespace: mycompany
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s29","action":"end"} -->
 
 The following example shows how to import TOSCA files using absolute
 path names (i.e. path names that start at the root of the repository):
 
+<!-- EDITOR_TAG{"type":"example","id":"s30","action":"start"} -->
 ```yaml
 # Root file
 imports:
 - url: /base.yaml
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s30","action":"end"} -->
 
 And finally, the following shows how to import TOSCA files from a
 repository that is different than the repository that contains the
 importing TOSCA file:
 
+<!-- EDITOR_TAG{"type":"example","id":"s31","action":"start"} -->
 ```yaml
 # External repository
 imports:
 - url: types/mytypes.yaml
   repository: my-repository
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s31","action":"end"} -->
 
 ### 6.8.4 Namespaces <a name=namespaces></a>
 
@@ -2555,6 +2617,7 @@ contain a node type definition for "MyNode":
 
 **TOSCA File B**
 
+<!-- EDITOR_TAG{"type":"example","id":"s32","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: TOSCA File B
@@ -2567,9 +2630,11 @@ node_types:
     capabilities:
       # omitted here for brevity
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s32","action":"end"} -->
 
 **TOSCA File A**
 
+<!-- EDITOR_TAG{"type":"example","id":"s33","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: TOSCA File A
@@ -2589,6 +2654,7 @@ service_template:
     my-node:
       type: MyNode
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s33","action":"end"} -->
 
 As you can see, TOSCA file A imports TOSCA file B which results in
 duplicate definitions of the MyNode node type. In this example, it is
@@ -2616,6 +2682,7 @@ disambiguate between the two "MyNode" type definitions. This first snippet
 shows the scenario where the "MyNode" definition from TOSCA file B is
 intended to be used:
 
+<!-- EDITOR_TAG{"type":"example","id":"s34","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: TOSCA file A
@@ -2636,10 +2703,12 @@ service_template:
     my-node:
       type: fileB:MyNode
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s34","action":"end"} -->
 
 The second snippet shows the scenario where the "MyNode" definition from
 TOSCA file A is intended to be used:
 
+<!-- EDITOR_TAG{"type":"example","id":"s35","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: TOSCA file A
@@ -2660,6 +2729,7 @@ service_template:
     my-node:
       type: MyNode
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s35","action":"end"} -->
 
 In many scenarios, imported TOSCA files may in turn import their own
 TOSCA files, and introduce their own namespaces to avoid name
@@ -2671,6 +2741,7 @@ Kubernetes profile into the "k8s" namespace. It defines a "SuperPod" node
 type that derives from the "Pod" node type defined in that Kubernetes
 profile:
 
+<!-- EDITOR_TAG{"type":"example","id":"s36","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: mytypes.yaml
@@ -2684,12 +2755,14 @@ node_types:
   SuperPod:
     derived_from: k8s:Pod
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s36","action":"end"} -->
 
 The "mytypes.yaml" file is then imported into the main.yaml TOSCA
 file, which defines both a node template of type "SuperPod" as well as a
 node template of type "Pod". Nested namespace names are used to identify
 the "Pod" node type from the Kubernetes profile:
 
+<!-- EDITOR_TAG{"type":"example","id":"s37","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: main.yaml
@@ -2705,6 +2778,7 @@ service_template:
     pod:
       type: my:k8s:Pod
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s37","action":"end"} -->
 
 Within each namespace (including the unnamed root namespace), names
 must be unique. This means that duplicate local names (i.e., within
@@ -2756,6 +2830,7 @@ The overall grammar of the service_template section is shown
 below. Detailed grammar definitions are provided in subsequent
 subsections.
 
+<!-- EDITOR_TAG{"type":"example","id":"s38","action":"start"} -->
 ```yaml
 service_template:
   description: <template_description>
@@ -2794,6 +2869,7 @@ service_template:
     <workflow_def_2>
     ...
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s38","action":"end"} -->
 
 In the above grammar, the placeholders that appear in angle brackets
 have the following meaning:
@@ -2861,6 +2937,7 @@ inputs:
 The following code snippet shows a simple `inputs` example without any
 validation clause:
 
+<!-- EDITOR_TAG{"type":"example","id":"s39","action":"start"} -->
 ```yaml
 inputs:
   foo-name:
@@ -2868,10 +2945,12 @@ inputs:
     description: Simple string parameter without a validation clause.
     default: bar
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s39","action":"end"} -->
 
 The following is an example of input parameter definitions with a
 validation clause:
 
+<!-- EDITOR_TAG{"type":"example","id":"s40","action":"start"} -->
 ```yaml
 inputs:
   site-name:
@@ -2880,6 +2959,7 @@ inputs:
     default: My Site
     validation: { $greater_or_equal: [ $value, 9 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s40","action":"end"} -->
 
 ### 6.9.3 Node Templates <a name=node-templates></a>
 
@@ -2898,6 +2978,7 @@ node_templates:
 
 The following code snippet shows an example of a `node_templates` section:
 
+<!-- EDITOR_TAG{"type":"example","id":"s41","action":"start"} -->
 ```yaml
 node_templates:
   my-webapp:
@@ -2906,6 +2987,7 @@ node_templates:
   my-database:
     type: Database
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s41","action":"end"} -->
 
 ### 6.9.4 Relationship Templates <a name=relationship-templates></a>
 
@@ -2928,6 +3010,7 @@ relationship_templates:
 The following code snippet shows an example of a `relationship_templates`
 section:
 
+<!-- EDITOR_TAG{"type":"example","id":"s42","action":"start"} -->
 ```yaml
 relationship_templates:
   my-connects-to:
@@ -2937,6 +3020,7 @@ relationship_templates:
         inputs:
           speed: { $get_attribute: [ SELF, SOURCE, connect-speed ] }      
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s42","action":"end"} -->
 
 ### 6.9.5 Output Parameters <a name=output-parameters></a>
 
@@ -2957,12 +3041,14 @@ outputs:
 
 The following code snippet shows an example of the `outputs` section:
 
+<!-- EDITOR_TAG{"type":"example","id":"s43","action":"start"} -->
 ```yaml
 outputs:
   server-address:
     description: The first private IP address for the provisioned server.
     value: { $get_attribute: [ node5, networks, private, addresses, 0 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s43","action":"end"} -->
 
 ### 6.9.6 Workflow Definitions <a name=workflow-definitions></a>
 
@@ -2981,12 +3067,14 @@ workflows:
 
 The following example shows the definition of a workflow:
 
+<!-- EDITOR_TAG{"type":"example","id":"s44","action":"start"} -->
 ```yaml
 workflows:
   scaling-workflow:
     steps:
       TO BE PROVIDED
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s44","action":"end"} -->
 
 ### 6.9.7 Group Definitions <a name=group-definitions></a>
 
@@ -3008,6 +3096,7 @@ The following example shows the definition of three "Compute" nodes in the
 `node_templates` section of a `service_template` as well as the grouping of
 two of the "Compute" nodes in group "servers":
 
+<!-- EDITOR_TAG{"type":"example","id":"s45","action":"start"} -->
 ```yaml
 node_templates:
   server1:
@@ -3028,6 +3117,7 @@ groups:
     type: MyScaling
     members: [ server2, server3 ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s45","action":"end"} -->
 
 ### 6.9.8 Policy Definitions <a name=policy-definitions></a>
 
@@ -3045,11 +3135,13 @@ policies:
 
 The following example shows the definition of a placement policy:
 
+<!-- EDITOR_TAG{"type":"example","id":"s46","action":"start"} -->
 ```yaml
 policies:
 - my-placement:
     type: Placement
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s46","action":"end"} -->
 
 ### 6.9.10 Substitution Mappings <a name=substitution-mappings></a>
 
@@ -3066,6 +3158,7 @@ substitution_mappings:
 
 The following code snippet shows an example substitution mapping:
 
+<!-- EDITOR_TAG{"type":"example","id":"s47","action":"start"} -->
 ```yaml
 service_template:
   inputs:
@@ -3094,6 +3187,7 @@ service_template:
       - foo: 
           ...
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s47","action":"end"} -->
 
 # 7 Nodes and Relationships <a name=nodes-and-relationships></a>
 
@@ -3225,6 +3319,7 @@ During node type derivation, the keynames follow these rules:
 
 The following code snippet shows an example node type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s48","action":"start"} -->
 ```yaml
 MyApp:
   derived_from: SoftwareComponent
@@ -3247,6 +3342,7 @@ MyApp:
       node: Database    
       relationship: ConnectsTo
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s48","action":"end"} -->
 
 ## 7.2 Node Template <a name=node-template></a>
 
@@ -3369,6 +3465,7 @@ have the following meaning:
 
 The following code snippet shows an example node template definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s49","action":"start"} -->
 ```yaml
 node_templates:
   mysql:
@@ -3383,6 +3480,7 @@ node_templates:
         operations:
           configure: scripts/my_own_configure.sh
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s49","action":"end"} -->
 
 ### 7.2.1 Node Template Directives<a name=node-template-directives</a>
 
@@ -3555,11 +3653,13 @@ rules:
 
 The following code snippet shows an example relationship type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s50","action":"start"} -->
 ```yaml
 AppDependency:
   derived_from: DependsOn
   valid_capability_types: [ SomeAppFeature ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s50","action":"end"} -->
 
 ## 7.4 Relationship Template <a name=relationship-template></a>
 
@@ -3657,6 +3757,7 @@ have the following meaning:
 
 The following code snippet shows an example relationship template definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s51","action":"start"} -->
 ```yaml
 relationship_templates:
   storage-attachment:
@@ -3664,6 +3765,7 @@ relationship_templates:
     properties:
       location: /my_mount_point
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s51","action":"end"} -->
 
 # 8 Capabilities and Requirements <a name=capabilities-and-requirements></a>
 
@@ -3764,6 +3866,7 @@ rules:
 The following code snippet shows an example capability type
 definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s52","action":"start"} -->
 ```yaml
 MyFeature:
   description: A custom feature of my company's application
@@ -3775,6 +3878,7 @@ MyFeature:
   valid_source_node_types:
   - MyCompanyNodes
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s52","action":"end"} -->
 
 ## 8.2 Capability Definition <a name=capability-def></a>
 
@@ -3869,6 +3973,7 @@ in the capability type:
 
 The following code snippet shows an example capability definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s53","action":"start"} -->
 ```yaml
 some-capability: 
   type: MyCapabilityTypeName
@@ -3876,12 +3981,15 @@ some-capability:
     limit: 
       default: 100
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s53","action":"end"} -->
 
 The following shows a capability definition using single-line grammar:
 
+<!-- EDITOR_TAG{"type":"example","id":"s54","action":"start"} -->
 ```yaml
 some-capability: MyCapabilityTypeName
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s54","action":"end"} -->
 
 ## 8.2.1 Capability Refinement <a name=capability-refinement></a>
 
@@ -3990,6 +4098,7 @@ have the following meaning:
 
 The following code snippet shows an example capability assignment:
 
+<!-- EDITOR_TAG{"type":"example","id":"s55","action":"start"} -->
 ```yaml
 node_templates:
   my-node:
@@ -3998,6 +4107,7 @@ node_templates:
         properties:
           limit: 100
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s55","action":"end"} -->
 
 ## 8.4 Requirement Definition <a name=requirement-def></a>
 
@@ -4477,6 +4587,7 @@ defines a web application node template named
 a requirement named "host" that needs to be fulfilled by any node that
 derives from the node type "WebServer":
 
+<!-- EDITOR_TAG{"type":"example","id":"s56","action":"start"} -->
 ```yaml
 service_template:
   node_templates:
@@ -4486,6 +4597,7 @@ service_template:
       - host: 
           node: WebServer
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s56","action":"end"} -->
 
 In this case, it is assumed that the "WebApplication" type defines a "host"
 requirement that uses relationship type "HostedOn" to relate to the target node.
@@ -4495,6 +4607,7 @@ be the specific target of the requirement in the target node.
 The following example targets a "WebServer" created from the "tomcat-server"
 template that has the same multiplicity index as the actual "my-application" node.
 
+<!-- EDITOR_TAG{"type":"example","id":"s57","action":"start"} -->
 ```yaml
 service_template:
   node_templates:
@@ -4505,6 +4618,7 @@ service_template:
       - host: 
           node: [ tomcat-server, $node_index ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s57","action":"end"} -->
 
 The following example shows a requirement named "database" that
 describes a requirement for a connection to a capability of type
@@ -4512,6 +4626,7 @@ describes a requirement for a connection to a capability of type
 the connection requires a custom relationship type
 ("CustomDbConnection") declared on the `relationship` keyname.
 
+<!-- EDITOR_TAG{"type":"example","id":"s58","action":"start"} -->
 ```yaml
 service_template:
   node_templates:
@@ -4523,6 +4638,7 @@ service_template:
           capability: Endpoint.Database
           relationship: CustomDbConnection
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s58","action":"end"} -->
 
 ### 8.5.4 Requirement Count <a name=requirement-count></a>
 
@@ -4557,6 +4673,7 @@ for handling requirement counts:
 The following example illustrates requirement assignment count
 rules. It uses the types defined in the following code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s59","action":"start"} -->
 ```yaml
 capability_types:
   Service:
@@ -4582,6 +4699,7 @@ node_types:
       service:
         type: Service
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s59","action":"end"} -->
 
 In this example, the "Client" node type defines a "service"
 requirement with a `count_range` of "[ 1, 4 ]". This means that a client
@@ -4598,6 +4716,7 @@ to the upper bound of the count range.
 The following shows a valid service template that uses `Client` and
 `Server` nodes:
 
+<!-- EDITOR_TAG{"type":"example","id":"s60","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -4623,11 +4742,13 @@ service_template:
       - service: server2
       - service: server3
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s60","action":"end"} -->
 
 In this example, the requirement assignments specify the target nodes
 directly, but it is also valid to leave requirements dangling as in
 the following example:
 
+<!-- EDITOR_TAG{"type":"example","id":"s61","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -4655,6 +4776,7 @@ service_template:
       - service:
           optional: true
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s61","action":"end"} -->
 
 In this example, only the first "service" assignment is non-optional. The
 next two are optional. However, after the orchestrator *fulfills* the
@@ -4707,6 +4829,7 @@ Another node with "num-cpu" with value 2 could not be a valid target since
 value which is 2. Of course, similar calculations must be done for the
 "mem-size" allocation.
 
+<!-- EDITOR_TAG{"type":"example","id":"s62","action":"start"} -->
 ```yaml
 service_template:
   node_templates:
@@ -4718,6 +4841,7 @@ service_template:
             num-cpu: 2
             mem-size: 128 MB
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s62","action":"end"} -->
 
 ## 8.6 Node Filter Definition <a name=node-filter-def></a>
 
@@ -4777,6 +4901,7 @@ support a specific range of CPUs (i.e., "num-cpus" value between 1 and 4)
 and memory size (i.e., "mem-size" of 2 or greater) from its declared
 "host" capability.
 
+<!-- EDITOR_TAG{"type":"example","id":"s63","action":"start"} -->
 ```yaml
 service_template:
   node_templates:
@@ -4793,6 +4918,7 @@ service_template:
                 - $get_property: [ SELF, CAPABILITY, mem-size ]
                 - 512 MB 
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s63","action":"end"} -->
 
 # 9 Properties, Attributes, and Parameters <a name=properties,-attributes,-and-parameters></a>
 
@@ -4876,6 +5002,7 @@ otherwise interpret as other types.
 This following example would be invalid if there were no quotation marks
 around "0.1":
 
+<!-- EDITOR_TAG{"type":"example","id":"s64","action":"start"} -->
 ```yaml
 node_types:
   Node:
@@ -4890,6 +5017,7 @@ service_template:
       properties:
         name: "0.1"
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s64","action":"end"} -->
 
 Please note:
 
@@ -4942,12 +5070,14 @@ enforce most of these variations using data type [validation clauses](#validatio
 For example, this would be a custom data type for unsigned 16-bit
 integers:
 
+<!-- EDITOR_TAG{"type":"example","id":"s65","action":"start"} -->
 ```yaml
 data_types:
   UInt16:
     derived_from: integer
     validation: { $in_range: [ $value, [ 0, 0xFFFF ] ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s65","action":"end"} -->
 
 YAML allows for the standard decimal notation as well as hexadecimal and
 octal notations [\[YAML-1.2\] example
@@ -4984,6 +5114,7 @@ integers that must be floats.
 
 Thus following example MUST NOT result in an error:
 
+<!-- EDITOR_TAG{"type":"example","id":"s66","action":"start"} -->
 ```yaml
 node_types:
   Node:
@@ -4998,6 +5129,7 @@ service_template:
       properties:
         speed: 10
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s66","action":"end"} -->
 
 Please note:
 
@@ -5037,6 +5169,7 @@ help you convert arbitrary data to Base64.
 
 Example:
 
+<!-- EDITOR_TAG{"type":"example","id":"s67","action":"start"} -->
 ```yaml
 ode_types:
   Node:
@@ -5055,6 +5188,7 @@ OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+\
 +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC\
 AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s67","action":"end"} -->
 
 Please note:
 
@@ -5080,6 +5214,7 @@ word "null".
 
 Example:
 
+<!-- EDITOR_TAG{"type":"example","id":"s68","action":"start"} -->
 ```yaml
 node_types:
   Node:
@@ -5095,6 +5230,7 @@ service_template:
       properties:
         nothing: null
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s68","action":"end"} -->
 
 Note that a `nil`-typed value is *distinct* from an unassigned value. For
 consistency TOSCA *requires* you to assign null values even though their
@@ -5103,6 +5239,7 @@ specify the null value for the property at the node template.
 
 Following is a valid example of *not* assigning a value:
 
+<!-- EDITOR_TAG{"type":"example","id":"s69","action":"start"} -->
 ```yaml
 node_types:
   Node:
@@ -5116,6 +5253,7 @@ service_template:
     my-node:
       type: Node
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s69","action":"end"} -->
 
 ### 9.1.2 Special Types <a name=special-types></a>
 
@@ -5243,6 +5381,7 @@ Note that `<unit>` is case sensitive. Implementors may guard against word overfl
 
 The following gives an example of the use of scalar:
 
+<!-- EDITOR_TAG{"type":"example","id":"s70","action":"start"} -->
 ```yaml
 dsl_definitions:
   # Defined a reusable set of prefixes taken from ISO80000
@@ -5318,6 +5457,7 @@ service_template:
         width: 125.3 mm # Definition is in millimeters, conversion of units within a scalar is performed by the parser
         throughput: 10 Kibits/s
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s70","action":"end"} -->
 
 During scalar type derivation the keyname definitions follow these
 rules in addition to the rules which apply to all data type derivations:
@@ -5338,6 +5478,7 @@ that existed in previous versions of the TOSCA specification, such that
 these might work as drop-in replacements. Note that our versions here are all
 case-sensitive.
 
+<!-- EDITOR_TAG{"type":"example","id":"s71","action":"start"} -->
 ```yaml
 dsl_definitions:
   iso-prefixes: &ISO80000
@@ -5395,6 +5536,7 @@ data_types:
       d:  86400
     validation: { $greater_or_equal: [ $value, 0.0 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s71","action":"end"} -->
 
 #### 9.1.2.3 `version` <a name=version></a>
 
@@ -5461,6 +5603,7 @@ comparison as follows:
 
 The following are examples of valid TOSCA version strings:
 
+<!-- EDITOR_TAG{"type":"example","id":"s72","action":"start"} -->
 ```yaml
 # basic version strings
 "6.1"
@@ -5472,6 +5615,7 @@ The following are examples of valid TOSCA version strings:
 # version string with optional qualifier and build version
 1.0.0.alpha-10
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s72","action":"end"} -->
 
 ### 9.1.3 Collection Types <a name=collection-types></a>
 
@@ -5514,23 +5658,28 @@ have the following meaning:
 The following example shows a list assignment using the square bracket
 notation:
 
+<!-- EDITOR_TAG{"type":"example","id":"s73","action":"start"} -->
 ```yaml
 listen-ports: [ 80, 8080 ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s73","action":"end"} -->
 
 The following example shows the same list assignment using the
 bulleted list notation:
 
+<!-- EDITOR_TAG{"type":"example","id":"s74","action":"start"} -->
 ```yaml
 listen-ports:
 - 80
 - 8080
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s74","action":"end"} -->
 
 The following example shows a list declaration with an entry schema
 based upon a simple integer type (which has an additional validation
 clause):
 
+<!-- EDITOR_TAG{"type":"example","id":"s75","action":"start"} -->
 ```yaml
 <some_entity>:
   ...
@@ -5542,10 +5691,12 @@ clause):
         type: integer
         validation: { $less_or_equal: [ $value, 128 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s75","action":"end"} -->
 
 The following example shows a list declaration with an entry schema
 based upon a complex type:
 
+<!-- EDITOR_TAG{"type":"example","id":"s76","action":"start"} -->
 ```yaml
 <some_entity>:
   ...
@@ -5556,6 +5707,7 @@ based upon a complex type:
         description: Product information entry (complex type) defined elsewhere
         type: ProductInfo
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s76","action":"end"} -->
 
 #### 9.1.3.2 `map` <a name=map></a>
 
@@ -5603,26 +5755,31 @@ have the following meaning:
 The following example shows the single-line option which is useful
 for only short maps with simple entries:
 
+<!-- EDITOR_TAG{"type":"example","id":"s77","action":"start"} -->
 ```yaml
 # notation option for shorter maps
 user-name-to-id: { user1: 1001, user2: 1002 }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s77","action":"end"} -->
 
 The next example shows the multi-line option where each map entry is
 on a separate line; this option is typically useful or more readable
 if there is a large number of entries, or if the entries are complex.
 
+<!-- EDITOR_TAG{"type":"example","id":"s78","action":"start"} -->
 ```yaml
 # notation for longer maps
 user-name-to-id:
   user1: 1001
   user2: 1002
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s78","action":"end"} -->
 
 The following example shows a declaration of a property of type map
 with an entry schema definition based upon the built-in string type
 (which has an additional validation clause):
 
+<!-- EDITOR_TAG{"type":"example","id":"s79","action":"start"} -->
 ```yaml
 <some_entity>:
   ...
@@ -5634,10 +5791,12 @@ with an entry schema definition based upon the built-in string type
         type: string
         validation: { $less_or_equal: [ $value, 128 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s79","action":"end"} -->
 
 The next example shows a map with an entry schema definition for
 contact information:
 
+<!-- EDITOR_TAG{"type":"example","id":"s80","action":"start"} -->
 ```yaml
 <some_entity>:
   ...
@@ -5648,6 +5807,7 @@ contact information:
         description: simple contact information
         type: ContactInfo
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s80","action":"end"} -->
 
 ## 9.2 Data Type <a name=data-type></a>
 
@@ -5746,14 +5906,17 @@ During data type derivation the keyname definitions follow these rules:
 The following code snippet shows an example data type definition that
 derives from the built-in "string" type:
 
+<!-- EDITOR_TAG{"type":"example","id":"s81","action":"start"} -->
 ```yaml
 ShortString:
   derived_from: string
   validation: { $less_or_equal: [ $value, 16 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s81","action":"end"} -->
 
 The next example defines a complex data type that represents a phone number:
 
+<!-- EDITOR_TAG{"type":"example","id":"s82","action":"start"} -->
 ```yaml
 PhoneNumber:
   properties:
@@ -5764,10 +5927,12 @@ PhoneNumber:
     number:
       type: integer
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s82","action":"end"} -->
 
 The following example shows a complex data type that derives from and
 extends a previously defined complex data type:
 
+<!-- EDITOR_TAG{"type":"example","id":"s83","action":"start"} -->
 ```yaml
 ExtendPhoneNumber:
   derived_from: PhoneNumber
@@ -5776,6 +5941,7 @@ ExtendPhoneNumber:
       type: string
       validation: { $less_or_equal: [ $value, 128 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s83","action":"end"} -->
 
 ## 9.3 Schema Definition <a name=schema-def></a>
 
@@ -6013,6 +6179,7 @@ definitions together:
 The following code snippet shows an example property definition with a
 validation clause:
 
+<!-- EDITOR_TAG{"type":"example","id":"s84","action":"start"} -->
 ```yaml
 properties:
   num-cpus:
@@ -6022,10 +6189,12 @@ properties:
     required: true
     validation: { $valid_values: [ $value, [ 1, 2, 4, 8 ] ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s84","action":"end"} -->
 
 The following shows an example of a property refinement. Consider the
 definition of an Endpoint capability type:
 
+<!-- EDITOR_TAG{"type":"example","id":"s85","action":"start"} -->
 ```yaml
 Endpoint:
   properties:
@@ -6041,11 +6210,13 @@ Endpoint:
       required: false
       default: false
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s85","action":"end"} -->
 
 The "Endpoint.Admin" capability type refines the secure property of the
 "Endpoint" capability type from which it derives by forcing its value to
 always be true:
 
+<!-- EDITOR_TAG{"type":"example","id":"s86","action":"start"} -->
 ```yaml
 Endpoint.Admin:
   derived_from: Endpoint
@@ -6053,6 +6224,7 @@ Endpoint.Admin:
   properties:
     secure: true
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s86","action":"end"} -->
 
 ## 9.4 Property Assignment <a name=property-assignment></a>
 
@@ -6206,11 +6378,13 @@ following refinement rules when the containing entity type is derived:
 
 The following represents a mandatory attribute definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s87","action":"start"} -->
 ```yaml
 actual_cpus:
   type: integer
   description: Actual number of CPUs allocated to the node instance.
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s87","action":"end"} -->
 
 ## 9.6 Attribute Assignment <a name=attribute-assignment></a>
 
@@ -6449,6 +6623,7 @@ the containing entity type is derived:
 The following represents an example of an input parameter definition
 with a validation clause:
 
+<!-- EDITOR_TAG{"type":"example","id":"s88","action":"start"} -->
 ```yaml
 inputs:
   cpus:
@@ -6456,16 +6631,19 @@ inputs:
     description: Number of CPUs for the server.
     validation: { $valid_values: [ $value, [ 1, 2, 4, 8 ] ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s88","action":"end"} -->
 
 The following represents an example of an (untyped) output parameter
 definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s89","action":"start"} -->
 ```yaml
 outputs:
   server-ip:
     description: The private IP address of the provisioned server.
     value: { $get_attribute: [ my-server, private-address ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s89","action":"end"} -->
 
 ## 9.8 Parameter Value Assignment <a name=parameter-value-assignment></a>
 
@@ -6588,6 +6766,7 @@ The following shows an example of validation clauses used in data type
 definitions. They also illustrate the various alternatives for the
 `$value` function syntax:
 
+<!-- EDITOR_TAG{"type":"example","id":"s90","action":"start"} -->
 ```yaml
 data_types:
   # Full function syntax for the $value function
@@ -6610,10 +6789,12 @@ data_types:
     validation:
       $greater_or_equal: [ { $value: [ high ] }, { $value: [ low ] } ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s90","action":"end"} -->
 
 The following shows an example of validation clauses used in property
 definitions:
 
+<!-- EDITOR_TAG{"type":"example","id":"s91","action":"start"} -->
 ```yaml
 node_types:
   Scalable:
@@ -6639,6 +6820,7 @@ node_types:
             - $get_property: [ SELF, maximum-instances ]
         required: false
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s91","action":"end"} -->
 
 # 10 TOSCA Functions <a name=tosca-functions></a>
 
@@ -6686,12 +6868,14 @@ second \$ character. For example, the following is a valid map where the
 function "keygen" is called three times and the returned values are used
 as keys in the hint map:
 
+<!-- EDITOR_TAG{"type":"example","id":"s92","action":"start"} -->
 ```yaml
 hint:
   { $keygen: [ UUID ] }: 34
   { $keygen$1: [ UUID ] }: 56
   { $keygen$2: [ UUID ] }: 78
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s92","action":"end"} -->
 
 TOSCA functions may be used wherever a value is expected, such as:
 
@@ -6710,23 +6894,28 @@ on the provided function arguments.
 The following snippet shows an example of a node template that uses a
 function to retrieve a security context at runtime:
 
+<!-- EDITOR_TAG{"type":"example","id":"s93","action":"start"} -->
 ```yaml
 properties:
   context: { $get_security_context: { env: staging, role: admin } }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s93","action":"end"} -->
 
 Nested functions are supported, that is, functions can be used in the
 arguments of another function. The result of the internal function will
 be passed as an argument to the outer function:
 
+<!-- EDITOR_TAG{"type":"example","id":"s94","action":"start"} -->
 ```yaml
 properties:
   nested: { $outer_func: [ { $inner_func: [ iarg1, iarg2 ] }, oarg2 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s94","action":"end"} -->
 
 The following snippet shows escaped strings in a map that
 do not represent function calls:
 
+<!-- EDITOR_TAG{"type":"example","id":"s95","action":"start"} -->
 ```yaml
 properties:
   prop1:
@@ -6734,6 +6923,7 @@ properties:
    myid2: $$myval2
    $$myid3: $$myval3
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s95","action":"end"} -->
 
 The arguments to the functions can be arbitrary TOSCA data, although
 TOSCA defines a number of built-in functions that define
@@ -6776,9 +6966,11 @@ $get_input: <input_parameter_name>
 
 or
 
+<!-- EDITOR_TAG{"type":"example","id":"s96","action":"start"} -->
 ```yaml
 $get_input: [ <input_parameter_name>, <nested_input_parameter_name_or_index_1>, <nested_input_parameter_name_or_index_2>, ... ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s96","action":"end"} -->
 
 Note that the signature shown in the first grammar does not conform to
 the custom function definition, but it does not have to as it is a
@@ -6794,6 +6986,7 @@ table:
 
 The following snippet shows an example of the simple `$get_input` grammar:
 
+<!-- EDITOR_TAG{"type":"example","id":"s97","action":"start"} -->
 ```yaml
 inputs:
   cpus:
@@ -6807,12 +7000,14 @@ node_templates:
         properties:
           num-cpus: { $get_input: cpus }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s97","action":"end"} -->
 
 The following template shows an example of the nested get_input grammar.
 The template expects two input values, each of which has a complex data
 type. The get_input function is used to retrieve individual fields from
 the complex input data.
 
+<!-- EDITOR_TAG{"type":"example","id":"s98","action":"start"} -->
 ```yaml
 data_types:
   NetworkInfo:
@@ -6851,6 +7046,7 @@ service_template:
             capability: VirtualBind
         - mgmt-net: mgmt-net
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s98","action":"end"} -->
 
 #### 10.2.1.2 `$get_property` <a name=get_property></a>
 
@@ -6881,6 +7077,7 @@ following table:
 The following example shows how to use the get_property function with an
 actual node template name:
 
+<!-- EDITOR_TAG{"type":"example","id":"s99","action":"start"} -->
 ```yaml
 node_templates:
   mysql-database:
@@ -6897,10 +7094,12 @@ node_templates:
           inputs:
             wp-db-name: { $get_property: [ mysql-database, name ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s99","action":"end"} -->
 
 The following example shows how to use the `$get_property` function
 traversing from the relationship to its target node:
 
+<!-- EDITOR_TAG{"type":"example","id":"s100","action":"start"} -->
 ```yaml
 relationship_templates:
   my-connection:
@@ -6910,6 +7109,7 @@ relationship_templates:
         inputs: 
           targets_value: { $get_property: [ SELF, TARGET, value ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s100","action":"end"} -->
 
 The following example shows how to use the get_property function using
 the "SELF" value, and traversing from a wordpress node (via the first
@@ -6917,6 +7117,7 @@ relationship of the database_endpoint requirement to the target
 capability in the target node) and accessing the port property of that
 capability:
 
+<!-- EDITOR_TAG{"type":"example","id":"s101","action":"start"} -->
 ```yaml
 node_templates:  
   mysql-database:
@@ -6948,12 +7149,14 @@ wordpress:
                - CAPABILITY
                - port
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s101","action":"end"} -->
 
 The following example shows how to use the `$get_property` function to
 traverse over two requirement relationships, from the "wordpress" node to
 its database node and further to its "DBMS" host to get its
 "admin-credential" property:
 
+<!-- EDITOR_TAG{"type":"example","id":"s102","action":"start"} -->
 ```yaml
 node_templates:  
   mysql-database:
@@ -6987,6 +7190,7 @@ node_templates:
               - TARGET
               - admin_credential
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s102","action":"end"} -->
 
 #### 10.2.1.3 `$get_attribute` <a name=get_attribute></a>
 
@@ -7038,6 +7242,7 @@ The following example uses a snippet of a WordPress
 [\[WordPress\]](#CIT_WORDPRESS) web application to show how to use the
 get_artifact function with an actual node template name:
 
+<!-- EDITOR_TAG{"type":"example","id":"s103","action":"start"} -->
 ```yaml
 node_templates:
   wordpress:
@@ -7053,6 +7258,7 @@ node_templates:
     artifacts:
       zip: /data/wordpress.zip
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s103","action":"end"} -->
 
 In such implementation the TOSCA orchestrator may provide the
 "wordpress.zip" archive as
@@ -7133,6 +7339,7 @@ following table:
 
 Usage example:
 
+<!-- EDITOR_TAG{"type":"example","id":"s104","action":"start"} -->
 ```yaml
 service_template:
   node_templates:
@@ -7147,6 +7354,7 @@ service_template:
           - $available_allocation: [ SELF, CAPABILITY, host, mem-size ]
           - 256 MB
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s104","action":"end"} -->
                   
 ### 10.2.2 Boolean Functions <a name=boolean-functions></a>
 
@@ -7460,6 +7668,7 @@ $concat: [<string_or_list_type_arg1>, ... ]
 
 The following code snippet shows an example of a `$concat` function:
 
+<!-- EDITOR_TAG{"type":"example","id":"s105","action":"start"} -->
 ```yaml
 outputs:
   description: Concatenate the URL for a server from other template values
@@ -7469,6 +7678,7 @@ outputs:
                      ':', 
                      $get_attribute: [ server, port ] ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s105","action":"end"} -->
 
 #### 10.2.3.3 `$join` <a name=join></a>
 
@@ -7492,6 +7702,7 @@ Argument|Mandatory|Type|Description
 
 The following code snippet shows example `$join` functions:
 
+<!-- EDITOR_TAG{"type":"example","id":"s106","action":"start"} -->
 ```yaml
 outputs:
   example1:
@@ -7501,6 +7712,7 @@ outputs:
     # Result: 9.12.1.10,9.12.1.20
     value: { $join: [ { $get_input: my-ips }, "," ] } 
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s106","action":"end"} -->
 
 #### 10.2.3.4 `$token` <a name=token></a>
 
@@ -7523,12 +7735,14 @@ Argument|Mandatory|Type|Description
 
 The following code snippet shows an example use of the `$token` function:
 
+<!-- EDITOR_TAG{"type":"example","id":"s107","action":"start"} -->
 ```yaml
 outputs:
   webserver_port:
     description: the port provided at the end of my server's endpoint's IP address
     value: { $token: [ $get_attribute: [ my-server, data-endpoint, ip-address ], ":", 1 ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s107","action":"end"} -->
 
 ### 10.2.4 Set Functions <a name=set-functions></a>
 
@@ -7904,10 +8118,12 @@ The functions section can be defined both outside and/or inside a
   - Note that in that case the `$` (dollar sign) character will be put in
     front of the namespace name. For example:
 
+<!-- EDITOR_TAG{"type":"example","id":"s108","action":"start"} -->
 ```yaml
 properties:
   rnd-nr: { $namespace1:random_generator: [ seed ] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s108","action":"end"} -->
 
 - Function definitions inside a service_template that have the
   same `<function_name>` are considered a refinement of the homonymous
@@ -7952,6 +8168,7 @@ refinement rules:
 
 The following example shows the definition of a square root function:
 
+<!-- EDITOR_TAG{"type":"example","id":"s109","action":"start"} -->
 ```yaml
 functions:
   sqrt:
@@ -7973,10 +8190,12 @@ functions:
       the argument is either integer or float and the function
       returns the square root as a float.
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s109","action":"end"} -->
 
 The next `$sqrt` is similar to above, but uses a simplified type notation
 (in this short form no validation clause can be expressed):
 
+<!-- EDITOR_TAG{"type":"example","id":"s110","action":"start"} -->
 ```yaml
 functions:
   sqrt:
@@ -7992,10 +8211,12 @@ functions:
       the argument is either integer or float and the function
       returns the suare root as a float
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s110","action":"end"} -->
 
 The following example shows a function that takes a list of arguments
 with different types:
 
+<!-- EDITOR_TAG{"type":"example","id":"s111","action":"start"} -->
 ```yaml
 functions:
   my_func_with_different_argument_types:
@@ -8014,10 +8235,12 @@ functions:
         type: MyTypeRez
       implementation: scripts/my.py
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s111","action":"end"} -->
 
 The following snippet defines the same function as the example above,
 but in compact notation:
 
+<!-- EDITOR_TAG{"type":"example","id":"s112","action":"start"} -->
 ```yaml
 functions:
   my_func_with_different_argument_types:
@@ -8027,10 +8250,12 @@ functions:
       result: MyTypeRez
     implementation: scripts/my.py
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s112","action":"end"} -->
 
 The arguments list can be empty or completely missing. In such a case,
 when using the function the arguments will be an empty list:
 
+<!-- EDITOR_TAG{"type":"example","id":"s113","action":"start"} -->
 ```yaml
 functions:
   get_random_nr:
@@ -8038,10 +8263,12 @@ functions:
     - result: float
       implementation: scripts/myrnd.py
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s113","action":"end"} -->
 
 The following shows function signatures with polymorphic arguments and
 result lists:
 
+<!-- EDITOR_TAG{"type":"example","id":"s114","action":"start"} -->
 ```yaml
 functions:
   union:
@@ -8063,10 +8290,12 @@ functions:
         entry_schema: float
       implementation: scripts/libpi.py
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s114","action":"end"} -->
 
 The following shows the use of an argument that is a map of lists of
 MyType:
 
+<!-- EDITOR_TAG{"type":"example","id":"s115","action":"start"} -->
 ```yaml
 functions:
   complex_arg_function:
@@ -8080,6 +8309,7 @@ functions:
         result: string
         implementation: scripts/complex.py
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s115","action":"end"} -->
 
 The following shows more examples of function usage. Note that in the
 usage of the polymorphic union function, the TOSCA parser knows to
@@ -8087,12 +8317,14 @@ identify the right signature via the types of the function arguments.
 Also note the usage of a user-defined function with no parameters; an
 empty list is used for the arguments.
 
+<!-- EDITOR_TAG{"type":"example","id":"s116","action":"start"} -->
 ```yaml
 properties:
   integer_union: { $union: [ [1, 7], [3, 4, 9], [15, 16] ] }
   float_union: { $union: [ [3.5, 8.8], [1.3] ] }
   rnd: { $get_random_nr: [] }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s116","action":"end"} -->
 
 # 11 Interfaces, Operations, and Notifications <a name=interfaces-operations-and-notifications></a>
 
@@ -8184,6 +8416,7 @@ implementations for defined operations or notifications; that is, the
 The following example shows a custom interface used to define multiple
 configure operations.
 
+<!-- EDITOR_TAG{"type":"example","id":"s117","action":"start"} -->
 ```yaml
 MyConfigure:
   description: My custom configure interface type
@@ -8196,6 +8429,7 @@ MyConfigure:
     post-configure-service:
       description: post-configure operation for my service
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s117","action":"end"} -->
 
 ## 11.2 Interface Definition <a name=interface-def></a>
 
@@ -8464,6 +8698,7 @@ The following additional requirements apply:
 
 The following code snippet shows an example operation definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s118","action":"start"} -->
 ```yaml
 interfaces:
   configure:
@@ -8478,9 +8713,11 @@ interfaces:
           type : Bash
           repository : my_service_catalog
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s118","action":"end"} -->
 
 The next example shows single-line grammar for the operation implementation:
 
+<!-- EDITOR_TAG{"type":"example","id":"s119","action":"start"} -->
 ```yaml
 interfaces:
   configure:
@@ -8492,15 +8729,18 @@ interfaces:
         - binaries/library.rpm
         - scripts/register.py
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s119","action":"end"} -->
 
 The following code snippet shows an example of the single-line grammar
 for the entire operation definitions:
 
+<!-- EDITOR_TAG{"type":"example","id":"s120","action":"start"} -->
 ```yaml
 interfaces:
   standard:
     start: scripts/start_server.sh
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s120","action":"end"} -->
 
 ## 11.5 Operation Assignment <a name=operation-assignment></a>
 
@@ -8969,6 +9209,7 @@ rules:
 
 The following shows an example artifact type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s121","action":"start"} -->
 ```yaml
 JavaArchive:
   description: Java Archive artifact type
@@ -8984,6 +9225,7 @@ JavaArchive:
       type: string
       required: false
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s121","action":"end"} -->
 
 Information about artifacts can be broadly classified in two categories
 that serve different purposes:
@@ -9083,6 +9325,7 @@ redefined.
 The following example represents an artifact definition with property
 assignments:
 
+<!-- EDITOR_TAG{"type":"example","id":"s122","action":"start"} -->
 ```yaml
 artifacts:
   sw-image:
@@ -9099,6 +9342,7 @@ artifacts:
       min-disk: 1 GB
       size: 649 MB
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s122","action":"end"} -->
 
 # 13 Workflows <a name=workflows></a>
 
@@ -9420,12 +9664,14 @@ have the following meaning:
 The following represents a list of activity definitions (using the short
 notation):
 
+<!-- EDITOR_TAG{"type":"example","id":"s123","action":"start"} -->
 ```yaml
 - delegate: deploy
 - set_state: started
 - call_operation: standard.start
 - inline: my-workflow
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s123","action":"end"} -->
 
 # 14 Creating Multiple Representations from Templates <a name=creating-multiple-representations-from-templates></a>
 
@@ -9487,6 +9733,7 @@ flowchart
 The following code snippet shows a possible TOSCA service template from which
 this service could be deployed:
 
+<!-- EDITOR_TAG{"type":"example","id":"s124","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: Template for deploying SD-WAN with three sites.
@@ -9525,6 +9772,7 @@ node_templates:
     requirements:
     - vpn: sdwan
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s124","action":"end"} -->
 
 As defined here, this template can only be used to deploy an SD-WAN
 with three sites. To deploy a different number of sites, additional
@@ -9564,6 +9812,7 @@ flowchart
 An implementation of such a service template is shown in the following
 code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s125","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: Template for deploying SD-WAN with a variable number of sites.
@@ -9583,6 +9832,7 @@ service_template:
       requirements:
       - vpn: sdwan
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s125","action":"end"} -->
 
 ## 14.2 Node-Specific Input Values <a name=node-specific-input-values></a>
 
@@ -9610,6 +9860,7 @@ The following service template shows how the `$node_index` function is
 used to retrieve specific values from a list of input values in a
 service template:
 
+<!-- EDITOR_TAG{"type":"example","id":"s126","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 description: Template for deploying SD-WAN with a variable number of sites.
@@ -9634,6 +9885,7 @@ service_template:
       requirements:
       - vpn: sdwan
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s126","action":"end"} -->
 
 ## 14.3 Cardinality of Relationships <a name=cardinality-of-relationships></a>
 
@@ -9673,6 +9925,7 @@ flowchart LR
 This scenario is supported using existing relationship syntax as
 shown in the following code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s127","action":"start"} -->
 ```yaml
 service_template:
   inputs:
@@ -9689,6 +9942,7 @@ service_template:
       requirements:
       - uses: right
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s127","action":"end"} -->
 
 This template specifies that all four node representations created
 from the "left" node template must use the one node representation
@@ -9723,6 +9977,7 @@ easily be accommodated using existing TOSCA grammar, as long as the
 requirement in the single node specifies the appropriate `count`
 value. This is shown in the following code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s128","action":"start"} -->
 ```yaml
 service_template:
   inputs:
@@ -9741,6 +9996,7 @@ service_template:
           node: right
           count: { $get_input: number-of-right }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s128","action":"end"} -->
 
 In this example, a total number of `count` relationships will be
 created from the single "left" node to the group of "right" nodes. The
@@ -9784,6 +10040,7 @@ the number of nodes on the right side is 1.
 As before, the full mesh scenario can easily be defined using existing
 requirement syntax as shown in the following code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s129","action":"start"} -->
 ```yaml
 service_template:
   inputs:
@@ -9805,6 +10062,7 @@ service_template:
           node: right
           count: { $get_input: number-of-right }
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s129","action":"end"} -->
 
 ### 14.3.4 Matched Pairs <a name=matched-pairs></a>
 
@@ -9860,6 +10118,7 @@ its source node. This following code snippet shows requirement
 definition grammar that uses the `$node_index` function to uniquely 
 identify target nodes:
 
+<!-- EDITOR_TAG{"type":"example","id":"s130","action":"start"} -->
 ```yaml
 service_template:
   inputs:
@@ -9877,6 +10136,7 @@ service_template:
       requirements:
       - uses: [ right, $node_index ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s130","action":"end"} -->
 
 ### 14.3.5 Random Pairs <a name=random-pairs></a>
 
@@ -9911,6 +10171,7 @@ source nodes, as long as each target node is only used once. To make
 sure each target node is only used once, the `allocations` keyname in
 the requirement can be used as shown in the following code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s131","action":"start"} -->
 ```yaml
 service_template:
   inputs:
@@ -9935,6 +10196,7 @@ service_template:
           allocations:
             target-count: 1
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s131","action":"end"} -->
 
 This scenario works as follows:
 
@@ -9989,6 +10251,7 @@ flowchart LR
 
 This pattern can be accomplished using the following code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s132","action":"start"} -->
 ```yaml
 service_template:
   node_templates:
@@ -10010,6 +10273,7 @@ service_template:
           allocations:
             target-count: 1
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s132","action":"end"} -->
 
 The following figure shows a 3:2 pattern:
 
@@ -10047,6 +10311,7 @@ flowchart LR
 
 This pattern can be implemented using the following code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s133","action":"start"} -->
 ```yaml
 service_template:
   node_templates:
@@ -10068,6 +10333,7 @@ service_template:
           allocations:
             target-count: 1
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s133","action":"end"} -->
 
 Finally, there may be scenarios where the multiplicity of the left
 nodes and the multiplicity of the right nodes do not allow clean
@@ -10078,6 +10344,7 @@ on the left than on the right. The following code snippet
 shows a *mismatched pairs* example where the orchestrator may have to
 cycle through the target nodes multiple times:
 
+<!-- EDITOR_TAG{"type":"example","id":"s134","action":"start"} -->
 ```yaml
 service_template:
   inputs:
@@ -10097,6 +10364,7 @@ service_template:
       requirements:
         - uses: [ right, { $remainder: [ $node_index, { $get_input: number-of-right } ] } ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s134","action":"end"} -->
 
 To allow specific input values to be matched with specific
 relationship representations, each relationship representation is
@@ -10448,6 +10716,7 @@ The following example shows a "Client" node type that defines a
 that nodes of type "Client" need exactly two "service" relationships
 to nodes of type "Server".
 
+<!-- EDITOR_TAG{"type":"example","id":"s135","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10475,6 +10744,7 @@ node_types:
       service:
         type: Service
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s135","action":"end"} -->
 
 This following figure shows a service that consists of one such client
 node connected to two server nodes.
@@ -10493,6 +10763,7 @@ dummy((.)) ~~~  client
 This service can be implemented using the following TOSCA service
 template:
 
+<!-- EDITOR_TAG{"type":"example","id":"s136","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10514,6 +10785,7 @@ service_template:
       - service: server1
       - service: server2
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s136","action":"end"} -->
 
 In this template, the "client" node is annotated with the
 "substitute" directive, which means that a substituting template must
@@ -10548,6 +10820,7 @@ requirements of the two software nodes in the substituting
 template. The substitution mapping code in the following substituting
 service template shows how this is accomplished:
 
+<!-- EDITOR_TAG{"type":"example","id":"s137","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10604,6 +10877,7 @@ service_template:
     compute2:
       type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s137","action":"end"} -->
 
 The following figure shows an alternative substitution where both
 "service" requirements of the substituted "client" node are mapped to
@@ -10635,6 +10909,7 @@ The requirement mapping syntax for this template distributes the two
 same* software node in the substituting template using two identical
 mappings for the two "service" requirements as follows:
 
+<!-- EDITOR_TAG{"type":"example","id":"s138","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10683,6 +10958,7 @@ service_template:
     compute:
       type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s138","action":"end"} -->
 
 As a convenience feature, it is possible to *group* identical mapping
 statements using the syntax in the following example. This syntax
@@ -10690,6 +10966,7 @@ states that two "service" requirements of the substituted node are
 mapped to two corresponding "service" requirements of the "software"
 node in the substituting template.
 
+<!-- EDITOR_TAG{"type":"example","id":"s139","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10737,6 +11014,7 @@ service_template:
     compute:
       type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s139","action":"end"} -->
 
 As a further convenience feature, if all of the requirement assignments
 are mapped to the same target requirement(s) is possible to drop the 
@@ -10744,6 +11022,7 @@ grammar using the count. This syntax states that all "service" requirements
 of the substituted node are mapped to the corresponding "service"
 requirements of the "software" node in the substituting template.
 
+<!-- EDITOR_TAG{"type":"example","id":"s140","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10791,12 +11070,14 @@ service_template:
     compute:
       type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s140","action":"end"} -->
 
 ### 15.5.2 Mapping a Requirement Multiple Times <a name=mapping-a-requirement-multiple-times></a>
 
 Imagine a scenario where nodes of type "Client" need to be hosted on
 nodes of type "Compute" as shown by the following type definitions:
 
+<!-- EDITOR_TAG{"type":"example","id":"s141","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10824,6 +11105,7 @@ node_types:
       host:
         type: Host
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s141","action":"end"} -->
 
 The following figure shows a service that contains one node of type
 "Client", one node of type "Compute", and the "host" relationship
@@ -10840,6 +11122,7 @@ flowchart RL
 
 This example can be implemented using the following service template:
 
+<!-- EDITOR_TAG{"type":"example","id":"s142","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10857,6 +11140,7 @@ service_template:
       requirements:
       - host: compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s142","action":"end"} -->
 
 The following figure shows a substituting topology that *decomposes*
 the node of type "Client" into two software components, each of which
@@ -10887,6 +11171,7 @@ accomplished by mapping the "host" requirement of the "client" node
 twice, once to the "host" requirement of the "software1" node and once
 to the "host" requirement of the "software2" node.
 
+<!-- EDITOR_TAG{"type":"example","id":"s143","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10916,6 +11201,7 @@ service_template:
     software2:
       type: ClientSoftware
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s143","action":"end"} -->
 
 Using this syntax, the target of the requirement mapping is a *list*
 of target requirements rather than a single requirement.
@@ -10952,6 +11238,7 @@ flowchart RL
 
 The following service template shows an implementation of this example:
 
+<!-- EDITOR_TAG{"type":"example","id":"s144","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -10969,6 +11256,7 @@ service_template:
       requirements:
       - host: compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s144","action":"end"} -->
 
 The following figure shows a substituting topology that *decomposes*
 the node of type "Client" into two software components, each of which
@@ -11013,6 +11301,7 @@ flowchart RL
 This can trivially be done using the syntax shown in the following
 code snippet:
 
+<!-- EDITOR_TAG{"type":"example","id":"s145","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -11044,6 +11333,7 @@ service_template:
       type: Compute
       directives: [select]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s145","action":"end"} -->
 
 The substitution mapping code in this service template provides an
 elegant mechanism for expressing that the target node of the "host"
@@ -11077,6 +11367,7 @@ the `count_range` in the corresponding requirement definition.
 The types defined in the following code snippet are used to illustrate
 these rules:
 
+<!-- EDITOR_TAG{"type":"example","id":"s146","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -11104,6 +11395,7 @@ node_types:
       service:
         type: Service
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s146","action":"end"} -->
 
 In this example, the "Client" node type defines a "service"
 requirement with a `count_range` of `[1, 4]`. This means that a client
@@ -11113,6 +11405,7 @@ one of those is mandatory.
 The following code snippet shows a valid substituting template for the
 "client" node in the template shown above:
 
+<!-- EDITOR_TAG{"type":"example","id":"s147","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -11160,6 +11453,7 @@ service_template:
     compute:
       type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s147","action":"end"} -->
 
 While the substituted "client" node in the template above has three
 requirement assigments with target nodes, only one of those
@@ -11174,6 +11468,7 @@ substitution mapping defines three requirement mappings for the
 "service" requirements of the "software" nodes in the substituting
 template.
 
+<!-- EDITOR_TAG{"type":"example","id":"s148","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -11239,6 +11534,7 @@ service_template:
     compute3:
       type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s148","action":"end"} -->
 
 Unfortunately, this substituting template is invalid. Since the
 "service" requirement of each "software" node is mandatory, this
@@ -11250,6 +11546,7 @@ means that only such requirement is guaranteed to exist.
 
 The following shows a corrected version of this substituting template:
 
+<!-- EDITOR_TAG{"type":"example","id":"s149","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -11317,6 +11614,7 @@ service_template:
     compute3:
       type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s149","action":"end"} -->
 
 In this template, the "service" requirement of the "ClientSoftware"
 node type is defined with a `count_range` of "[0, 1]", which means the
@@ -11346,6 +11644,7 @@ are mapped to the corresponding "service" requirements of the "software1"
 node in the substituting template. This allows for the follwing compact
 syntax:
 
+<!-- EDITOR_TAG{"type":"example","id":"s150","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -11396,6 +11695,7 @@ service_template:
     compute:
       type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s150","action":"end"} -->
 
 In the next case the "service" requirements of the substituted node
 are mapped to the corresponding "service" requirements of both the
@@ -11407,6 +11707,7 @@ node, then the rest of the "service" requirements of the substituted
 node are mapped again to the "service" requirement of the "software1"
 node:
 
+<!-- EDITOR_TAG{"type":"example","id":"s151","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -11459,6 +11760,7 @@ node_templates:
   compute:
     type: Compute
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s151","action":"end"} -->
 
 ## 15.6 Interface Mapping <a name=interface-mapping></a>
 
@@ -11580,12 +11882,14 @@ During group type derivation the keyname definitions follow these rules:
 
 The following represents an example group type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s152","action":"start"} -->
 ```yaml
 group_types:
   Placement:
     description: My company's group type for placing nodes of type Software
     members: [ Software ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s152","action":"end"} -->
 
 ## 16.2 Group Definition <a name=group-def></a>
 
@@ -11655,6 +11959,7 @@ have the following meaning:
 
 The following represents a group definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s153","action":"start"} -->
 ```yaml
 groups:
   my-app-placement:
@@ -11662,6 +11967,7 @@ groups:
     description: My application's logical component grouping for placement
     members: [ my-web-server, my-sql-database ]
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s153","action":"end"} -->
 
 ## 16.3 Policy Type <a name=policy-type></a>
 
@@ -11742,11 +12048,13 @@ rules:
 
 The following represents a policy type definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s154","action":"start"} -->
 ```yaml
 policy_types:
   Placement.Container.Linux:
     description: My company's placement policy for linux 
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s154","action":"end"} -->
 
 ## 16.4 Policy Definition <a name=policy-def></a>
 
@@ -11815,6 +12123,7 @@ have the following meaning:
 
 The following represents a policy definition:
 
+<!-- EDITOR_TAG{"type":"example","id":"s155","action":"start"} -->
 ```yaml
 - my-compute-placement:
     type: Placement
@@ -11822,6 +12131,7 @@ The following represents a policy definition:
     targets: [ my_server_1, my_server_2 ]
     # remainder of policy definition omitted for brevity
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s155","action":"end"} -->
 
 ## 16.5 Trigger Definition <a name=trigger-def></a>
 
@@ -12068,6 +12378,7 @@ have only one service template defined in a YAML file.
 The following represents a valid TOSCA template file acting as the CSAR
 `Entry-Definitions` file in an archive without a "TOSCA.meta" file.
 
+<!-- EDITOR_TAG{"type":"example","id":"s156","action":"start"} -->
 ```yaml
 tosca_definitions_version: tosca_2_0
 
@@ -12076,6 +12387,7 @@ metadata:
   template_author: OASIS TOSCA TC
   template_version: '1.0'
 ```
+<!-- EDITOR_TAG{"type":"example","id":"s156","action":"end"} -->
 
 -------
 

--- a/tosca_2_0/examples/s1.yaml
+++ b/tosca_2_0/examples/s1.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s1","action":"start"} -->
+MyMap:
+  property1: value
+  property2: [ value1, value2 ]
+# EDITOR_TAG:{"type":"example","id":"s1","action":"end"} -->

--- a/tosca_2_0/examples/s10.yaml
+++ b/tosca_2_0/examples/s10.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s10","action":"start"} -->
+artifact_types:
+  MyFile:
+    derived_from: foobar:File
+# EDITOR_TAG:{"type":"example","id":"s10","action":"end"} -->

--- a/tosca_2_0/examples/s100.yaml
+++ b/tosca_2_0/examples/s100.yaml
@@ -1,0 +1,10 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s100","action":"start"} -->
+relationship_templates:
+  my-connection:
+    type: ConnectsTo
+    interfaces:
+      configure:
+        inputs: 
+          targets_value: { $get_property: [ SELF, TARGET, value ] }
+# EDITOR_TAG:{"type":"example","id":"s100","action":"end"} -->

--- a/tosca_2_0/examples/s101.yaml
+++ b/tosca_2_0/examples/s101.yaml
@@ -1,0 +1,32 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s101","action":"start"} -->
+node_templates:  
+  mysql-database:
+    type: Database
+    ...
+    capabilities:
+      database-endpoint:
+        properties:
+          port: 3306
+
+wordpress:
+    type: WordPress
+    requirements:
+      ...
+      - database-endpoint: mysql-database
+    interfaces:
+      standard:
+        create: wordpress_install.sh
+        configure: 
+          implementation: wordpress_configure.sh            
+          inputs:
+            ...
+            wp-db-port:
+              $get_property:
+               - SELF
+               - RELATIONSHIP
+               - database-endpoint
+               - 0
+               - CAPABILITY
+               - port
+# EDITOR_TAG:{"type":"example","id":"s101","action":"end"} -->

--- a/tosca_2_0/examples/s102.yaml
+++ b/tosca_2_0/examples/s102.yaml
@@ -1,0 +1,34 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s102","action":"start"} -->
+node_templates:  
+  mysql-database:
+    type: Database
+    ...
+    capabilities:
+      database-endpoint:
+        properties:
+          port: 3306
+
+  wordpress:
+    type: WordPress
+    requirements:
+      ...
+      - database-endpoint: mysql-database
+    interfaces:
+      standard:
+        create: wordpress_install.sh
+        configure: 
+          implementation: wordpress_configure.sh            
+          inputs:
+            ...
+            host-dbms-admin-credential:
+              $get_property:
+              - SELF
+              - RELATIONSHIP
+              - database_endpoint
+              - TARGET
+              - RELATIONSHIP
+              - host
+              - TARGET
+              - admin_credential
+# EDITOR_TAG:{"type":"example","id":"s102","action":"end"} -->

--- a/tosca_2_0/examples/s103.yaml
+++ b/tosca_2_0/examples/s103.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s103","action":"start"} -->
+node_templates:
+  wordpress:
+    type: WordPress
+    ...
+    interfaces:
+      standard:
+        configure: 
+          create:
+            implementation: wordpress_install.sh
+            inputs:
+              wp-zip: { $get_artifact: [ SELF, zip ] }
+    artifacts:
+      zip: /data/wordpress.zip
+# EDITOR_TAG:{"type":"example","id":"s103","action":"end"} -->

--- a/tosca_2_0/examples/s104.yaml
+++ b/tosca_2_0/examples/s104.yaml
@@ -1,0 +1,15 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s104","action":"start"} -->
+service_template:
+  node_templates:
+    my-node:
+      directive: [ select ]
+      node_filter:
+        $and:
+        - $greater_or_equal:
+          - $available_allocation: [ SELF, CAPABILITY, host, num-cpus ]
+          - 3
+        - $greater_or_equal:
+          - $available_allocation: [ SELF, CAPABILITY, host, mem-size ]
+          - 256 MB
+# EDITOR_TAG:{"type":"example","id":"s104","action":"end"} -->

--- a/tosca_2_0/examples/s105.yaml
+++ b/tosca_2_0/examples/s105.yaml
@@ -1,0 +1,10 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s105","action":"start"} -->
+outputs:
+  description: Concatenate the URL for a server from other template values
+  server-url:
+  value: { $concat: [ 'http://', 
+                     $get_attribute: [ server, public_address ],
+                     ':', 
+                     $get_attribute: [ server, port ] ] }
+# EDITOR_TAG:{"type":"example","id":"s105","action":"end"} -->

--- a/tosca_2_0/examples/s106.yaml
+++ b/tosca_2_0/examples/s106.yaml
@@ -1,0 +1,10 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s106","action":"start"} -->
+outputs:
+  example1:
+    # Result: prefix_1111_suffix
+    value: { $join: [ [ "prefix", 1111, "suffix" ], "_" ] }
+  example2:
+    # Result: 9.12.1.10,9.12.1.20
+    value: { $join: [ { $get_input: my-ips }, "," ] } 
+# EDITOR_TAG:{"type":"example","id":"s106","action":"end"} -->

--- a/tosca_2_0/examples/s107.yaml
+++ b/tosca_2_0/examples/s107.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s107","action":"start"} -->
+outputs:
+  webserver_port:
+    description: the port provided at the end of my server's endpoint's IP address
+    value: { $token: [ $get_attribute: [ my-server, data-endpoint, ip-address ], ":", 1 ] }
+# EDITOR_TAG:{"type":"example","id":"s107","action":"end"} -->

--- a/tosca_2_0/examples/s108.yaml
+++ b/tosca_2_0/examples/s108.yaml
@@ -1,0 +1,5 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s108","action":"start"} -->
+properties:
+  rnd-nr: { $namespace1:random_generator: [ seed ] }
+# EDITOR_TAG:{"type":"example","id":"s108","action":"end"} -->

--- a/tosca_2_0/examples/s109.yaml
+++ b/tosca_2_0/examples/s109.yaml
@@ -1,0 +1,22 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s109","action":"start"} -->
+functions:
+  sqrt:
+    signatures:
+    - arguments:
+      - type: integer
+        validation: { $greater_or_equal: [ $value, 0 ] }
+      result:
+        type: float
+      implementation: scripts/sqrt.py
+    - arguments:
+      - type: float
+        validation: { $greater_or_equal: [ $value, 0.0 ] }
+      result:
+        type: float
+      implementation: scripts/sqrt.py
+    description: >
+      This is a square root function that defines two signatures:
+      the argument is either integer or float and the function
+      returns the square root as a float.
+# EDITOR_TAG:{"type":"example","id":"s109","action":"end"} -->

--- a/tosca_2_0/examples/s11.yaml
+++ b/tosca_2_0/examples/s11.yaml
@@ -1,0 +1,17 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s11","action":"start"} -->
+capability_types:
+  MyGenericFeature:
+    properties:
+      # more details ...
+
+  MyFirstCustomFeature:
+    derived_from: MyGenericFeature
+    properties:
+      # more details ...
+
+  TransactSQL:
+    derived_from: MyGenericFeature
+    properties:
+      # more details ...
+# EDITOR_TAG:{"type":"example","id":"s11","action":"end"} -->

--- a/tosca_2_0/examples/s110.yaml
+++ b/tosca_2_0/examples/s110.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s110","action":"start"} -->
+functions:
+  sqrt:
+    signatures:
+    - arguments: [ integer ]
+      result: float
+      implementation: scripts/sqrt.py
+    - arguments: [ float ]
+      result: float
+      implementation: scripts/sqrt.py
+    description: >
+      This is a square root function that defines two signatures:
+      the argument is either integer or float and the function
+      returns the suare root as a float
+# EDITOR_TAG:{"type":"example","id":"s110","action":"end"} -->

--- a/tosca_2_0/examples/s111.yaml
+++ b/tosca_2_0/examples/s111.yaml
@@ -1,0 +1,19 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s111","action":"start"} -->
+functions:
+  my_func_with_different_argument_types:
+    signatures:
+    - arguments:
+      - type: MyType1
+        description: "this is the first argument ..."
+      - type: string
+        description: "this is the second argument ..."
+      - type: string
+        description: "this is the third argument ..."
+      - type: MyType2
+        description: "this is the argument that can be repeated ..."
+      variadic: true
+      result: 
+        type: MyTypeRez
+      implementation: scripts/my.py
+# EDITOR_TAG:{"type":"example","id":"s111","action":"end"} -->

--- a/tosca_2_0/examples/s112.yaml
+++ b/tosca_2_0/examples/s112.yaml
@@ -1,0 +1,10 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s112","action":"start"} -->
+functions:
+  my_func_with_different_argument_types:
+    signatures:
+    - arguments: [ MyType1, string, string, MyType2 ]
+      variadic: true
+      result: MyTypeRez
+    implementation: scripts/my.py
+# EDITOR_TAG:{"type":"example","id":"s112","action":"end"} -->

--- a/tosca_2_0/examples/s113.yaml
+++ b/tosca_2_0/examples/s113.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s113","action":"start"} -->
+functions:
+  get_random_nr:
+    signatures:
+    - result: float
+      implementation: scripts/myrnd.py
+# EDITOR_TAG:{"type":"example","id":"s113","action":"end"} -->

--- a/tosca_2_0/examples/s114.yaml
+++ b/tosca_2_0/examples/s114.yaml
@@ -1,0 +1,22 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s114","action":"start"} -->
+functions:
+  union:
+    signatures:
+    - arguments:
+      - type: list
+        entry_schema: integer
+      variadic: true
+      result:
+        type: list
+        entry_schema: integer
+      implementation: scripts/libpi.py
+    - arguments:
+      - type: list
+        entry_schema: float
+      variadic: true
+      result:
+        type: list
+        entry_schema: float
+      implementation: scripts/libpi.py
+# EDITOR_TAG:{"type":"example","id":"s114","action":"end"} -->

--- a/tosca_2_0/examples/s115.yaml
+++ b/tosca_2_0/examples/s115.yaml
@@ -1,0 +1,14 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s115","action":"start"} -->
+functions:
+  complex_arg_function:
+    signatures:
+      - arguments: 
+        - type: map
+          key_schema: string
+          entry_schema:
+            type: list
+            entry_schema: MyType
+        result: string
+        implementation: scripts/complex.py
+# EDITOR_TAG:{"type":"example","id":"s115","action":"end"} -->

--- a/tosca_2_0/examples/s116.yaml
+++ b/tosca_2_0/examples/s116.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s116","action":"start"} -->
+properties:
+  integer_union: { $union: [ [1, 7], [3, 4, 9], [15, 16] ] }
+  float_union: { $union: [ [3.5, 8.8], [1.3] ] }
+  rnd: { $get_random_nr: [] }
+# EDITOR_TAG:{"type":"example","id":"s116","action":"end"} -->

--- a/tosca_2_0/examples/s117.yaml
+++ b/tosca_2_0/examples/s117.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s117","action":"start"} -->
+MyConfigure:
+  description: My custom configure interface type
+  inputs:
+    mode:
+      type: string
+  operations:
+    pre-configure-service:
+      description: pre-configure operation for my service
+    post-configure-service:
+      description: post-configure operation for my service
+# EDITOR_TAG:{"type":"example","id":"s117","action":"end"} -->

--- a/tosca_2_0/examples/s118.yaml
+++ b/tosca_2_0/examples/s118.yaml
@@ -1,0 +1,15 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s118","action":"start"} -->
+interfaces:
+  configure:
+    pre-configure-source:
+      implementation: 
+        primary: 
+          file: scripts/pre_configure_source.sh
+          type: Bash
+          repository: my_service_catalog
+        dependencies:
+        - file : scripts/setup.sh
+          type : Bash
+          repository : my_service_catalog
+# EDITOR_TAG:{"type":"example","id":"s118","action":"end"} -->

--- a/tosca_2_0/examples/s119.yaml
+++ b/tosca_2_0/examples/s119.yaml
@@ -1,0 +1,12 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s119","action":"start"} -->
+interfaces:
+  configure:
+    pre-configure-source:
+      implementation: 
+        primary: scripts/pre_configure_source.sh
+        dependencies: 
+        - scripts/setup.sh
+        - binaries/library.rpm
+        - scripts/register.py
+# EDITOR_TAG:{"type":"example","id":"s119","action":"end"} -->

--- a/tosca_2_0/examples/s12.yaml
+++ b/tosca_2_0/examples/s12.yaml
@@ -1,0 +1,10 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s12","action":"start"} -->
+interface_types:
+  Signal:
+    operations:
+      signal-begin-receive:
+        description: Operation to signal start of some message processing.
+      signal-end-receive:
+        description: Operation to signal end of some message processed.
+# EDITOR_TAG:{"type":"example","id":"s12","action":"end"} -->

--- a/tosca_2_0/examples/s120.yaml
+++ b/tosca_2_0/examples/s120.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s120","action":"start"} -->
+interfaces:
+  standard:
+    start: scripts/start_server.sh
+# EDITOR_TAG:{"type":"example","id":"s120","action":"end"} -->

--- a/tosca_2_0/examples/s121.yaml
+++ b/tosca_2_0/examples/s121.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s121","action":"start"} -->
+JavaArchive:
+  description: Java Archive artifact type
+  mime_type: application/java-archive
+  file_ext: [ jar ]
+  properties:
+    id: 
+      description: Identifier of the jar
+      type: string
+      required: true
+    creator:
+      description: Vendor of the java implementation on which the jar is based
+      type: string
+      required: false
+# EDITOR_TAG:{"type":"example","id":"s121","action":"end"} -->

--- a/tosca_2_0/examples/s122.yaml
+++ b/tosca_2_0/examples/s122.yaml
@@ -1,0 +1,17 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s122","action":"start"} -->
+artifacts:
+  sw-image:
+    description: Image for virtual machine
+    type: Deployment.Image.VM
+    file: http://10.10.86.141/images/Juniper_vSRX_15.1x49_D80_preconfigured.qcow2
+    checksum: ba411cafee2f0f702572369da0b765e2
+    version: '3.2'
+    checksum_algorithm: MD5
+    properties:
+      name: vSRX
+      container-format: BARE
+      disk-format: QCOW2
+      min-disk: 1 GB
+      size: 649 MB
+# EDITOR_TAG:{"type":"example","id":"s122","action":"end"} -->

--- a/tosca_2_0/examples/s123.yaml
+++ b/tosca_2_0/examples/s123.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s123","action":"start"} -->
+- delegate: deploy
+- set_state: started
+- call_operation: standard.start
+- inline: my-workflow
+# EDITOR_TAG:{"type":"example","id":"s123","action":"end"} -->

--- a/tosca_2_0/examples/s124.yaml
+++ b/tosca_2_0/examples/s124.yaml
@@ -1,0 +1,39 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s124","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: Template for deploying SD-WAN with three sites.
+
+service_template:
+  inputs:
+    location1:
+      type: Location
+    location2:
+      type: Location
+    location3:
+      type: Location
+
+node_templates:
+  sdwan:
+    type: VPN
+
+  site1:
+    type: VPNSite
+    properties:
+      location: { $get_input: location1 }
+    requirements:
+    - vpn: sdwan
+
+  site2:
+    type: VPNSite
+    properties:
+      location: { $get_input: location2 }
+    requirements:
+    - vpn: sdwan
+
+  site3:
+    type: VPNSite
+    properties:
+      location: { $get_input: location3 }
+    requirements:
+    - vpn: sdwan
+# EDITOR_TAG:{"type":"example","id":"s124","action":"end"} -->

--- a/tosca_2_0/examples/s125.yaml
+++ b/tosca_2_0/examples/s125.yaml
@@ -1,0 +1,20 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s125","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: Template for deploying SD-WAN with a variable number of sites.
+
+service_template:
+  inputs:
+    number-of-sites:
+      type: integer
+
+  node_templates:
+    sdwan:
+      type: VPN
+
+    site:
+      type: VPNSite
+      count: { $get_input: number-of-sites }
+      requirements:
+      - vpn: sdwan
+# EDITOR_TAG:{"type":"example","id":"s125","action":"end"} -->

--- a/tosca_2_0/examples/s126.yaml
+++ b/tosca_2_0/examples/s126.yaml
@@ -1,0 +1,25 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s126","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: Template for deploying SD-WAN with a variable number of sites.
+
+service_template:
+  inputs:
+    number-of-sites:
+      type: integer
+    location:
+      type: list
+      entry_schema: Location
+
+  node_templates:
+    sdwan:
+      type: VPN
+
+    site:
+      type: VPNSite
+      count: { $get_input: number-of-sites }
+      properties:
+        location: { $get_input: [ location, $node_index ] }
+      requirements:
+      - vpn: sdwan
+# EDITOR_TAG:{"type":"example","id":"s126","action":"end"} -->

--- a/tosca_2_0/examples/s127.yaml
+++ b/tosca_2_0/examples/s127.yaml
@@ -1,0 +1,17 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s127","action":"start"} -->
+service_template:
+  inputs:
+    number-of-left:
+      type: integer
+
+  node_templates:
+    right:
+      type: Right
+
+    left:
+      type: Left
+      count: { $get_input: number-of-left }
+      requirements:
+      - uses: right
+# EDITOR_TAG:{"type":"example","id":"s127","action":"end"} -->

--- a/tosca_2_0/examples/s128.yaml
+++ b/tosca_2_0/examples/s128.yaml
@@ -1,0 +1,19 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s128","action":"start"} -->
+service_template:
+  inputs:
+    number-of-right:
+      type: integer
+
+  node_templates:
+    right:
+      type: Right
+      count: { $get_input: number_of_right }
+
+    left:
+      type: Left
+      requirements:
+      - uses:
+          node: right
+          count: { $get_input: number-of-right }
+# EDITOR_TAG:{"type":"example","id":"s128","action":"end"} -->

--- a/tosca_2_0/examples/s129.yaml
+++ b/tosca_2_0/examples/s129.yaml
@@ -1,0 +1,22 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s129","action":"start"} -->
+service_template:
+  inputs:
+    number-of-left:
+      type: integer
+    number-of-right:
+      type: integer
+
+  node_templates:
+    right:
+      type: Right
+      count: { $get_input: number-of-right }
+
+    left:
+      type: Left
+      count: { $get_input: number-of-left }
+      requirements:
+      - uses:
+          node: right
+          count: { $get_input: number-of-right }
+# EDITOR_TAG:{"type":"example","id":"s129","action":"end"} -->

--- a/tosca_2_0/examples/s13.yaml
+++ b/tosca_2_0/examples/s13.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s13","action":"start"} -->
+relationship_types:
+  HostedOn:
+    properties:
+      # more details ...
+
+  MyCustomClientServer:
+    derived_from: HostedOn
+    properties:
+      # more details ...
+
+  MyCustomConnectionType:
+    properties:
+      # more details ...
+# EDITOR_TAG:{"type":"example","id":"s13","action":"end"} -->

--- a/tosca_2_0/examples/s130.yaml
+++ b/tosca_2_0/examples/s130.yaml
@@ -1,0 +1,18 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s130","action":"start"} -->
+service_template:
+  inputs:
+    number-of-nodes:
+      type: integer
+
+  node_templates:
+    right:
+      type: Right
+      count: { $get_input: number_of_nodes }
+
+    left:
+      type: Left
+      count: { $get_input: number-of-nodes }
+      requirements:
+      - uses: [ right, $node_index ]
+# EDITOR_TAG:{"type":"example","id":"s130","action":"end"} -->

--- a/tosca_2_0/examples/s131.yaml
+++ b/tosca_2_0/examples/s131.yaml
@@ -1,0 +1,25 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s131","action":"start"} -->
+service_template:
+  inputs:
+    number-of-nodes:
+      type: integer
+
+  node_templates:
+    right:
+      type: Right
+      count: { $get_input: number-of-nodes }
+      capabilities:
+        feature:
+          properties:
+            target-count: 1
+
+    left:
+      type: Left
+      count: { $get_input: number-of-nodes }
+      requirements:
+      - uses:
+          node: right
+          allocations:
+            target-count: 1
+# EDITOR_TAG:{"type":"example","id":"s131","action":"end"} -->

--- a/tosca_2_0/examples/s132.yaml
+++ b/tosca_2_0/examples/s132.yaml
@@ -1,0 +1,22 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s132","action":"start"} -->
+service_template:
+  node_templates:
+    right:
+      type: Right
+      count: 6
+      capabilities:
+        feature:
+          properties:
+            target-count: 1
+
+    left:
+      type: Left
+      count: 6
+      requirements:
+      - uses:
+          node: right
+          count: 2
+          allocations:
+            target-count: 1
+# EDITOR_TAG:{"type":"example","id":"s132","action":"end"} -->

--- a/tosca_2_0/examples/s133.yaml
+++ b/tosca_2_0/examples/s133.yaml
@@ -1,0 +1,22 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s133","action":"start"} -->
+service_template:
+  node_templates:
+    right:
+      type: Right
+      count: 6
+      capabilities:
+        feature:
+          properties:
+            target-count: 3
+
+    left:
+      type: Left
+      count: 6
+      requirements:
+      - uses:
+          node: right
+          count: 2
+          allocations:
+            target-count: 1
+# EDITOR_TAG:{"type":"example","id":"s133","action":"end"} -->

--- a/tosca_2_0/examples/s134.yaml
+++ b/tosca_2_0/examples/s134.yaml
@@ -1,0 +1,20 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s134","action":"start"} -->
+service_template:
+  inputs:
+    number-of-right:
+      type: integer
+    number-of-left:
+      type: integer
+
+  node_templates:
+    right:
+      type: Right
+      count: { $get_input: number-of-right }
+
+    left:
+      type: Left
+      count: { $get_input: number-of-left }
+      requirements:
+        - uses: [ right, { $remainder: [ $node_index, { $get_input: number-of-right } ] } ]
+# EDITOR_TAG:{"type":"example","id":"s134","action":"end"} -->

--- a/tosca_2_0/examples/s135.yaml
+++ b/tosca_2_0/examples/s135.yaml
@@ -1,0 +1,28 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s135","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+capability_types:
+  Service:
+    description: >-
+      Ability to provide service.
+
+relationship_types:
+  ServedBy:
+    description: >-
+      Connection to a service.
+
+node_types:
+  Client:
+    requirements:
+    - service:
+        capability: Service
+        relationship: ServedBy
+        node: Server
+        count_range: [ 2, 2 ]
+
+  Server:
+    capabilities:
+      service:
+        type: Service
+# EDITOR_TAG:{"type":"example","id":"s135","action":"end"} -->

--- a/tosca_2_0/examples/s136.yaml
+++ b/tosca_2_0/examples/s136.yaml
@@ -1,0 +1,22 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s136","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+service_template:
+  node_templates:
+    server1:
+      type: Server
+
+    server2:
+      type: Server
+
+    client:
+      type: Client
+      directives: [ substitute ]
+      requirements:
+      - service: server1
+      - service: server2
+# EDITOR_TAG:{"type":"example","id":"s136","action":"end"} -->

--- a/tosca_2_0/examples/s137.yaml
+++ b/tosca_2_0/examples/s137.yaml
@@ -1,0 +1,57 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s137","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+capability_types:
+  Host:
+    description: >-
+      Ability to host software.
+
+relationship_types:
+  HostedOn:
+    description: >-
+      Relationship to a host.
+
+node_types:
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 1, 1 ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - service: [ software1, service ]
+    - service: [ software2, service ]
+
+  node_templates:
+    software1:
+      type: ClientSoftware
+      requirements:
+      - host: compute1
+
+    software2:
+      type: ClientSoftware
+      requirements:
+      - host: compute2
+
+    compute1:
+      type: Compute
+
+    compute2:
+      type: Compute
+# EDITOR_TAG:{"type":"example","id":"s137","action":"end"} -->

--- a/tosca_2_0/examples/s138.yaml
+++ b/tosca_2_0/examples/s138.yaml
@@ -1,0 +1,49 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s138","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+capability_types:
+  Host:
+    description: >-
+      Ability to host software.
+
+relationship_types:
+  HostedOn:
+    description: >-
+      Relationship to a host.
+
+node_types:
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 2, 2 ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - service: [ software, service ]
+    - service: [ software, service ]
+
+  node_templates:
+    software:
+      type: ClientSoftware
+      requirements:
+      - host: compute
+
+    compute:
+      type: Compute
+# EDITOR_TAG:{"type":"example","id":"s138","action":"end"} -->

--- a/tosca_2_0/examples/s139.yaml
+++ b/tosca_2_0/examples/s139.yaml
@@ -1,0 +1,48 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s139","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+capability_types:
+  Host:
+    description: >-
+      Ability to host software.
+
+relationship_types:
+  HostedOn:
+    description: >-
+      Relationship to a host.
+
+node_types:
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 2, 2 ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - [ service, 2 ]: [ software, service ]
+
+  node_templates:
+    software:
+      type: ClientSoftware
+      requirements:
+      - host: compute
+
+    compute:
+      type: Compute
+# EDITOR_TAG:{"type":"example","id":"s139","action":"end"} -->

--- a/tosca_2_0/examples/s14.yaml
+++ b/tosca_2_0/examples/s14.yaml
@@ -1,0 +1,20 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s14","action":"start"} -->
+node_types:
+  Database:
+    description: A generic node type for all databases
+
+  WebApplication:
+    description: A generic node type
+
+  MyWebApplication:
+    derived_from: WebApplication
+    properties:
+      my-port:
+        type: integer
+
+  MyDatabase:
+    derived_from: Database
+    capabilities:
+      TransactSQL
+# EDITOR_TAG:{"type":"example","id":"s14","action":"end"} -->

--- a/tosca_2_0/examples/s140.yaml
+++ b/tosca_2_0/examples/s140.yaml
@@ -1,0 +1,48 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s140","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+capability_types:
+  Host:
+    description: >-
+      Ability to host software.
+
+relationship_types:
+  HostedOn:
+    description: >-
+      Relationship to a host.
+
+node_types:
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 2, 2 ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - service: [ software, service ]
+
+  node_templates:
+    software:
+      type: ClientSoftware
+      requirements:
+      - host: compute
+
+    compute:
+      type: Compute
+# EDITOR_TAG:{"type":"example","id":"s140","action":"end"} -->

--- a/tosca_2_0/examples/s141.yaml
+++ b/tosca_2_0/examples/s141.yaml
@@ -1,0 +1,28 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s141","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+capability_types:
+  Host:
+    description: >-
+      Ability to host software.
+
+relationship_types:
+  HostedOn:
+    description: >-
+      Relationship to a host.
+
+node_types:
+  Client:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+        node: Compute
+        count_range: [ 1, 1 ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+# EDITOR_TAG:{"type":"example","id":"s141","action":"end"} -->

--- a/tosca_2_0/examples/s142.yaml
+++ b/tosca_2_0/examples/s142.yaml
@@ -1,0 +1,18 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s142","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+service_template:
+  node_templates:
+    compute:
+      type: Compute
+
+    client:
+      type: Client
+      directives: [ substitute ]
+      requirements:
+      - host: compute
+# EDITOR_TAG:{"type":"example","id":"s142","action":"end"} -->

--- a/tosca_2_0/examples/s143.yaml
+++ b/tosca_2_0/examples/s143.yaml
@@ -1,0 +1,30 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s143","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+node_types:
+  ClientSoftware:
+    requirements:
+      - host:
+          capability: Host
+          relationship: HostedOn
+          count_range: [ 1, 1 ]
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - host:
+      - [ software1, host ]
+      - [ software2, host ]
+
+  node_templates:
+    software1:
+      type: ClientSoftware
+
+    software2:
+      type: ClientSoftware
+# EDITOR_TAG:{"type":"example","id":"s143","action":"end"} -->

--- a/tosca_2_0/examples/s144.yaml
+++ b/tosca_2_0/examples/s144.yaml
@@ -1,0 +1,18 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s144","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+service_template:
+  node_templates:
+    compute:
+      type: Compute
+
+    client:
+      type: Client
+      directives: [ substitute ]
+      requirements:
+      - host: compute
+# EDITOR_TAG:{"type":"example","id":"s144","action":"end"} -->

--- a/tosca_2_0/examples/s145.yaml
+++ b/tosca_2_0/examples/s145.yaml
@@ -1,0 +1,32 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s145","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+node_types:
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+        count_range: [ 1, 1 ]
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - host: compute
+
+  node_templates:
+    software1:
+      type: ClientSoftware
+
+    software2:
+      type: ClientSoftware
+
+    compute:
+      type: Compute
+      directives: [select]
+# EDITOR_TAG:{"type":"example","id":"s145","action":"end"} -->

--- a/tosca_2_0/examples/s146.yaml
+++ b/tosca_2_0/examples/s146.yaml
@@ -1,0 +1,28 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s146","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+capability_types:
+  Service:
+    description: >-
+      Ability to provide service.
+
+relationship_types:
+  ServedBy:
+    description: >-
+      Connection to a service.
+
+node_types:
+  Client:
+    requirements:
+    - service:
+        capability: Service
+        relationship: ServedBy
+        node: Server
+        count_range: [ 1, 4 ]
+
+  Server:
+    capabilities:
+      service:
+        type: Service
+# EDITOR_TAG:{"type":"example","id":"s146","action":"end"} -->

--- a/tosca_2_0/examples/s147.yaml
+++ b/tosca_2_0/examples/s147.yaml
@@ -1,0 +1,48 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s147","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+capability_types:
+  Host:
+    description: >-
+      Ability to host software.
+
+relationship_types:
+  HostedOn:
+    description: >-
+      Relationship to a host.
+
+node_types:
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 1, 1 ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - service: [ software, service ]
+
+  node_templates:
+    software:
+      type: ClientSoftware
+      requirements:
+      - host: compute
+
+    compute:
+      type: Compute
+# EDITOR_TAG:{"type":"example","id":"s147","action":"end"} -->

--- a/tosca_2_0/examples/s148.yaml
+++ b/tosca_2_0/examples/s148.yaml
@@ -1,0 +1,66 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s148","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+capability_types:
+  Host:
+    description: >-
+      Ability to host software.
+
+relationship_types:
+  HostedOn:
+    description: >-
+      Relationship to a host.
+
+node_types:
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 1, 1 ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - service: [ software1, service ]
+    - service: [ software2, service ]
+    - service: [ software3, service ]
+
+  node_templates:
+    software1:
+      type: ClientSoftware
+      requirements:
+      - host: compute1
+
+    software2:
+      type: ClientSoftware
+      requirements:
+      - host: compute2
+
+    software3:
+      type: ClientSoftware
+      requirements:
+      - host: compute3
+
+    compute1:
+      type: Compute
+
+    compute2:
+      type: Compute
+
+    compute3:
+      type: Compute
+# EDITOR_TAG:{"type":"example","id":"s148","action":"end"} -->

--- a/tosca_2_0/examples/s149.yaml
+++ b/tosca_2_0/examples/s149.yaml
@@ -1,0 +1,68 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s149","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+capability_types:
+  Host:
+    description: >-
+      Ability to host software.
+
+relationship_types:
+  HostedOn:
+    description: >-
+      Relationship to a host.
+
+node_types:
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 0, 1 ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - service: [ software1, service ]
+    - service: [ software2, service ]
+    - service: [ software3, service ]
+
+  node_templates:
+    software1:
+      type: ClientSoftware
+      requirements:
+      - host: compute1
+      - service:
+          optional: false
+
+    software2:
+      type: ClientSoftware
+      requirements:
+      - host: compute2
+
+    software3:
+      type: ClientSoftware
+      requirements:
+      - host: compute3
+
+    compute1:
+      type: Compute
+
+    compute2:
+      type: Compute
+
+    compute3:
+      type: Compute
+# EDITOR_TAG:{"type":"example","id":"s149","action":"end"} -->

--- a/tosca_2_0/examples/s15.yaml
+++ b/tosca_2_0/examples/s15.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s15","action":"start"} -->
+group_types:
+  MyScalingGroup:
+    derived_from: foobar:MyGroup
+# EDITOR_TAG:{"type":"example","id":"s15","action":"end"} -->

--- a/tosca_2_0/examples/s150.yaml
+++ b/tosca_2_0/examples/s150.yaml
@@ -1,0 +1,51 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s150","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+node_types:
+  Client:
+    requirements:
+    - service:
+        capability: Service
+        relationship: ServedBy
+        node: Server
+        count_range: [ 3, UNBOUNDED ]
+
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 0, UNBOUNDED ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - service: [ software1, service ]
+
+  node_templates:
+    software1:
+      type: ClientSoftware
+      requirements:
+      - host: compute
+
+    software2:
+      type: ClientSoftware
+      requirements:
+      - host: compute
+
+    compute:
+      type: Compute
+# EDITOR_TAG:{"type":"example","id":"s150","action":"end"} -->

--- a/tosca_2_0/examples/s151.yaml
+++ b/tosca_2_0/examples/s151.yaml
@@ -1,0 +1,53 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s151","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+node_types:
+  Client:
+    requirements:
+    - service:
+        capability: Service
+        relationship: ServedBy
+        node: Server
+        count_range: [ 3, UNBOUNDED ]
+
+  ClientSoftware:
+    requirements:
+    - host:
+        capability: Host
+        relationship: HostedOn
+    - service:
+        capability: Service
+        relationship: ServedBy
+        count_range: [ 0, UNBOUNDED ]
+
+  Compute:
+    capabilities:
+      host:
+        type: Host
+
+service_template:
+  substitution_mappings:
+    node_type: Client
+    requirements:
+    - service: [ software1, service ]
+    - service: [ software2, service ]
+    - [ service, UNBOUNDED ]: [ software1, service ]
+
+node_templates:
+  software1:
+    type: ClientSoftware
+    requirements:
+    - host: compute
+
+  software2:
+    type: ClientSoftware
+    requirements:
+    - host: compute
+
+  compute:
+    type: Compute
+# EDITOR_TAG:{"type":"example","id":"s151","action":"end"} -->

--- a/tosca_2_0/examples/s152.yaml
+++ b/tosca_2_0/examples/s152.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s152","action":"start"} -->
+group_types:
+  Placement:
+    description: My company's group type for placing nodes of type Software
+    members: [ Software ]
+# EDITOR_TAG:{"type":"example","id":"s152","action":"end"} -->

--- a/tosca_2_0/examples/s153.yaml
+++ b/tosca_2_0/examples/s153.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s153","action":"start"} -->
+groups:
+  my-app-placement:
+    type: Placement
+    description: My application's logical component grouping for placement
+    members: [ my-web-server, my-sql-database ]
+# EDITOR_TAG:{"type":"example","id":"s153","action":"end"} -->

--- a/tosca_2_0/examples/s154.yaml
+++ b/tosca_2_0/examples/s154.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s154","action":"start"} -->
+policy_types:
+  Placement.Container.Linux:
+    description: My company's placement policy for linux 
+# EDITOR_TAG:{"type":"example","id":"s154","action":"end"} -->

--- a/tosca_2_0/examples/s155.yaml
+++ b/tosca_2_0/examples/s155.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s155","action":"start"} -->
+- my-compute-placement:
+    type: Placement
+    description: Apply my placement policy to my application's servers
+    targets: [ my_server_1, my_server_2 ]
+    # remainder of policy definition omitted for brevity
+# EDITOR_TAG:{"type":"example","id":"s155","action":"end"} -->

--- a/tosca_2_0/examples/s156.yaml
+++ b/tosca_2_0/examples/s156.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s156","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+metadata:
+  template_name: my_template
+  template_author: OASIS TOSCA TC
+  template_version: '1.0'
+# EDITOR_TAG:{"type":"example","id":"s156","action":"end"} -->

--- a/tosca_2_0/examples/s16.yaml
+++ b/tosca_2_0/examples/s16.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s16","action":"start"} -->
+policy_types:
+  MyScalingPolicy:
+    derived_from: foobar:Scaling
+# EDITOR_TAG:{"type":"example","id":"s16","action":"end"} -->

--- a/tosca_2_0/examples/s17.yaml
+++ b/tosca_2_0/examples/s17.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s17","action":"start"} -->
+repositories:
+  my-project:
+    description: My project's code repository in GitHub
+    url: https://github.com/my-project/
+
+  external-repo: https://foo.bar
+# EDITOR_TAG:{"type":"example","id":"s17","action":"end"} -->

--- a/tosca_2_0/examples/s18.yaml
+++ b/tosca_2_0/examples/s18.yaml
@@ -1,0 +1,22 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s18","action":"start"} -->
+functions:
+  sqrt:
+    signatures:
+    - arguments:
+      - type: integer
+        validation: { $greater_or_equal: [ $value, 0 ] }
+      result:
+        type: float
+      implementation: scripts/sqrt.py
+    - arguments:
+      - type: float
+        validation: { $greater_or_equal: [ $value, 0.0 ] }
+      result:
+        type: float
+      implementation: scripts/sqrt.py
+    description: >
+      This is a square root function that defines two signatures:
+      the argument is either integer or float and the function
+      returns the square root as a float.
+# EDITOR_TAG:{"type":"example","id":"s18","action":"end"} -->

--- a/tosca_2_0/examples/s19.yaml
+++ b/tosca_2_0/examples/s19.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s19","action":"start"} -->
+profile: com.example.tosca_profiles.cloud_computing:2.0 
+# EDITOR_TAG:{"type":"example","id":"s19","action":"end"} -->

--- a/tosca_2_0/examples/s2.yaml
+++ b/tosca_2_0/examples/s2.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s2","action":"start"} -->
+metadata:
+  <metadata_name_1>: <metadata_value_1>
+  <metadata_name_2>: <metadata_value_2>
+  ...
+# EDITOR_TAG:{"type":"example","id":"s2","action":"end"} -->

--- a/tosca_2_0/examples/s20.yaml
+++ b/tosca_2_0/examples/s20.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s20","action":"start"} -->
+profile: io.kubernetes:1.30
+# EDITOR_TAG:{"type":"example","id":"s20","action":"end"} -->

--- a/tosca_2_0/examples/s21.yaml
+++ b/tosca_2_0/examples/s21.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s21","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+profile: org.base:v1
+
+capability_types:
+  Host:
+    description: Hosting capability
+
+relationship_types:
+  HostedOn:
+    valid_capability_types: [ Host ]
+# EDITOR_TAG:{"type":"example","id":"s21","action":"end"} -->

--- a/tosca_2_0/examples/s22.yaml
+++ b/tosca_2_0/examples/s22.yaml
@@ -1,0 +1,15 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s22","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+profile: org.platform
+
+imports:
+- profile: org.base:v1
+  namespace: p1
+
+node_types:
+  Platform:
+    capabilities:
+      host:
+        type: p1:Host
+# EDITOR_TAG:{"type":"example","id":"s22","action":"end"} -->

--- a/tosca_2_0/examples/s23.yaml
+++ b/tosca_2_0/examples/s23.yaml
@@ -1,0 +1,19 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s23","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+profile: org.base:v2
+
+capability_types:
+  Host:
+    description: Hosting capability
+
+relationship_types:
+  HostedOn:
+    valid_capability_types: [ Host ]
+
+data_types:
+  Credential:
+    properties:
+      key:
+        type: string
+# EDITOR_TAG:{"type":"example","id":"s23","action":"end"} -->

--- a/tosca_2_0/examples/s24.yaml
+++ b/tosca_2_0/examples/s24.yaml
@@ -1,0 +1,32 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s24","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- profile: org.base:v2
+  namespace: p2
+- profile: org.platform
+  namespace: pl
+
+node_types:
+  Service:
+    properties:
+      credential:
+        type: p2:Credential
+    requirements:
+    - host:
+        capability: p2:Host
+        relationship: p2:HostedOn
+
+service_template:
+  node_templates:
+    service:
+      type: Service
+      properties:
+        credential:
+          key: password
+      requirements:
+      - host: platform
+    platform:
+      type: pl:Platform
+# EDITOR_TAG:{"type":"example","id":"s24","action":"end"} -->

--- a/tosca_2_0/examples/s25.yaml
+++ b/tosca_2_0/examples/s25.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s25","action":"start"} -->
+# Importing a profile
+imports:
+- profile: org.oasis-open.tosca.simple:2.0
+# EDITOR_TAG:{"type":"example","id":"s25","action":"end"} -->

--- a/tosca_2_0/examples/s26.yaml
+++ b/tosca_2_0/examples/s26.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s26","action":"start"} -->
+# Absolute URL with scheme
+imports:
+- url: https://myorg.org/tosca/types/mytypes.yaml
+# EDITOR_TAG:{"type":"example","id":"s26","action":"end"} -->

--- a/tosca_2_0/examples/s27.yaml
+++ b/tosca_2_0/examples/s27.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s27","action":"start"} -->
+# Short notation supported
+imports:
+- ../types/mytypes.yaml 
+# EDITOR_TAG:{"type":"example","id":"s27","action":"end"} -->

--- a/tosca_2_0/examples/s28.yaml
+++ b/tosca_2_0/examples/s28.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s28","action":"start"} -->
+# Long notation
+imports:
+- url: ../types/mytypes.yaml
+# EDITOR_TAG:{"type":"example","id":"s28","action":"end"} -->

--- a/tosca_2_0/examples/s29.yaml
+++ b/tosca_2_0/examples/s29.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s29","action":"start"} -->
+# Short notation and long notation supported
+imports:
+- relative_path/my_defns/my_typesdefs_1.yaml
+- url: my_defns/my_typesdefs_2.yaml    
+  repository: my-company-repo
+  namespace: mycompany
+# EDITOR_TAG:{"type":"example","id":"s29","action":"end"} -->

--- a/tosca_2_0/examples/s3.yaml
+++ b/tosca_2_0/examples/s3.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s3","action":"start"} -->
+metadata: 
+  creation-date: 2024-04-14
+  date-updated: 2024-05-01
+  status: developmental  
+# EDITOR_TAG:{"type":"example","id":"s3","action":"end"} -->

--- a/tosca_2_0/examples/s30.yaml
+++ b/tosca_2_0/examples/s30.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s30","action":"start"} -->
+# Root file
+imports:
+- url: /base.yaml
+# EDITOR_TAG:{"type":"example","id":"s30","action":"end"} -->

--- a/tosca_2_0/examples/s31.yaml
+++ b/tosca_2_0/examples/s31.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s31","action":"start"} -->
+# External repository
+imports:
+- url: types/mytypes.yaml
+  repository: my-repository
+# EDITOR_TAG:{"type":"example","id":"s31","action":"end"} -->

--- a/tosca_2_0/examples/s32.yaml
+++ b/tosca_2_0/examples/s32.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s32","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: TOSCA File B
+  
+node_types:
+  MyNode:
+    derived_from: SoftwareComponent
+    properties:
+      # omitted here for brevity 
+    capabilities:
+      # omitted here for brevity
+# EDITOR_TAG:{"type":"example","id":"s32","action":"end"} -->

--- a/tosca_2_0/examples/s33.yaml
+++ b/tosca_2_0/examples/s33.yaml
@@ -1,0 +1,20 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s33","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: TOSCA File A
+
+imports:
+- url: /templates/TOSCAFileB.yaml
+
+node_types:
+  MyNode:
+    properties:
+      # omitted here for brevity 
+    capabilities:
+      # omitted here for brevity
+
+service_template:
+  node_templates:
+    my-node:
+      type: MyNode
+# EDITOR_TAG:{"type":"example","id":"s33","action":"end"} -->

--- a/tosca_2_0/examples/s34.yaml
+++ b/tosca_2_0/examples/s34.yaml
@@ -1,0 +1,21 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s34","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: TOSCA file A
+
+imports:
+- url: /templates/TOSCAFileB.yaml
+  namespace: fileB
+
+node_types:
+  MyNode:
+    properties:
+      # omitted here for brevity 
+    capabilities:
+      # omitted here for brevity
+
+service_template:
+  node_templates:
+    my-node:
+      type: fileB:MyNode
+# EDITOR_TAG:{"type":"example","id":"s34","action":"end"} -->

--- a/tosca_2_0/examples/s35.yaml
+++ b/tosca_2_0/examples/s35.yaml
@@ -1,0 +1,21 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s35","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: TOSCA file A
+
+imports:
+- url: /templates/TOSCAFileB.yaml
+  namespace: fileB
+
+node_types:
+  MyNode:
+    properties:
+      # omitted here for brevity 
+    capabilities:
+      # omitted here for brevity
+
+service_template:
+  node_templates:
+    my-node:
+      type: MyNode
+# EDITOR_TAG:{"type":"example","id":"s35","action":"end"} -->

--- a/tosca_2_0/examples/s36.yaml
+++ b/tosca_2_0/examples/s36.yaml
@@ -1,0 +1,14 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s36","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: mytypes.yaml
+
+imports:
+- profile: io.kubernetes:1.30
+  namespace: k8s
+
+node_types:
+  MyNode: {}
+  SuperPod:
+    derived_from: k8s:Pod
+# EDITOR_TAG:{"type":"example","id":"s36","action":"end"} -->

--- a/tosca_2_0/examples/s37.yaml
+++ b/tosca_2_0/examples/s37.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s37","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+description: main.yaml
+
+imports:
+- url: mytypes.yaml
+  namespace: my
+
+service_template:
+  node_templates:
+    my-node:
+      type: my:MyType
+    pod:
+      type: my:k8s:Pod
+# EDITOR_TAG:{"type":"example","id":"s37","action":"end"} -->

--- a/tosca_2_0/examples/s38.yaml
+++ b/tosca_2_0/examples/s38.yaml
@@ -1,0 +1,39 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s38","action":"start"} -->
+service_template:
+  description: <template_description>
+  metadata:
+    <metadata_name_1>: <metadata_value_1>
+    <metadata_name_2>: <metadata_value_2>
+    ...
+  inputs:
+    <input_parameter_def_1>
+    <input_parameter_def_2>
+    ...
+  outputs:
+    <output_parameter_def_1>
+    <output_parameter_def_2>
+    ...
+  node_templates:
+    <node_template_def_1>
+    <node_template_def_2>
+    ...
+  relationship_templates: 
+    <relationship_template_def_1>
+    <relationship_template_def_2>
+    ...
+  groups:
+    <group_def_1>
+    <group_def_2>
+    ...
+  policies: 
+  - <policy_def_1>
+  - <policy_def_2>
+  - ...
+  substitution_mappings:
+    <substitution_mappings>
+  workflows:
+    <workflow_def_1>
+    <workflow_def_2>
+    ...
+# EDITOR_TAG:{"type":"example","id":"s38","action":"end"} -->

--- a/tosca_2_0/examples/s39.yaml
+++ b/tosca_2_0/examples/s39.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s39","action":"start"} -->
+inputs:
+  foo-name:
+    type: string
+    description: Simple string parameter without a validation clause.
+    default: bar
+# EDITOR_TAG:{"type":"example","id":"s39","action":"end"} -->

--- a/tosca_2_0/examples/s4.yaml
+++ b/tosca_2_0/examples/s4.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s4","action":"start"} -->
+description: <description_string>
+# EDITOR_TAG:{"type":"example","id":"s4","action":"end"} -->

--- a/tosca_2_0/examples/s40.yaml
+++ b/tosca_2_0/examples/s40.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s40","action":"start"} -->
+inputs:
+  site-name:
+    type: string
+    description: String parameter with validation clause.
+    default: My Site
+    validation: { $greater_or_equal: [ $value, 9 ] }
+# EDITOR_TAG:{"type":"example","id":"s40","action":"end"} -->

--- a/tosca_2_0/examples/s41.yaml
+++ b/tosca_2_0/examples/s41.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s41","action":"start"} -->
+node_templates:
+  my-webapp:
+    type: WebApplication
+
+  my-database:
+    type: Database
+# EDITOR_TAG:{"type":"example","id":"s41","action":"end"} -->

--- a/tosca_2_0/examples/s42.yaml
+++ b/tosca_2_0/examples/s42.yaml
@@ -1,0 +1,10 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s42","action":"start"} -->
+relationship_templates:
+  my-connects-to:
+    type: ConnectsTo
+    interfaces:
+      configure:
+        inputs:
+          speed: { $get_attribute: [ SELF, SOURCE, connect-speed ] }      
+# EDITOR_TAG:{"type":"example","id":"s42","action":"end"} -->

--- a/tosca_2_0/examples/s43.yaml
+++ b/tosca_2_0/examples/s43.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s43","action":"start"} -->
+outputs:
+  server-address:
+    description: The first private IP address for the provisioned server.
+    value: { $get_attribute: [ node5, networks, private, addresses, 0 ] }
+# EDITOR_TAG:{"type":"example","id":"s43","action":"end"} -->

--- a/tosca_2_0/examples/s44.yaml
+++ b/tosca_2_0/examples/s44.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s44","action":"start"} -->
+workflows:
+  scaling-workflow:
+    steps:
+      TO BE PROVIDED
+# EDITOR_TAG:{"type":"example","id":"s44","action":"end"} -->

--- a/tosca_2_0/examples/s45.yaml
+++ b/tosca_2_0/examples/s45.yaml
@@ -1,0 +1,21 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s45","action":"start"} -->
+node_templates:
+  server1:
+    type: Compute
+    # more details ...
+
+  server2:
+    type: Compute
+    # more details ...
+
+  server3:
+    type: Compute
+    # more details ...
+
+groups:
+  # server2 and server3 are part of the same group
+  servers:
+    type: MyScaling
+    members: [ server2, server3 ]
+# EDITOR_TAG:{"type":"example","id":"s45","action":"end"} -->

--- a/tosca_2_0/examples/s46.yaml
+++ b/tosca_2_0/examples/s46.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s46","action":"start"} -->
+policies:
+- my-placement:
+    type: Placement
+# EDITOR_TAG:{"type":"example","id":"s46","action":"end"} -->

--- a/tosca_2_0/examples/s47.yaml
+++ b/tosca_2_0/examples/s47.yaml
@@ -1,0 +1,29 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s47","action":"start"} -->
+service_template:
+  inputs:
+   cpus: 
+     type: integer
+     validation: { $less_than: [ $value, 5 ] }
+
+  substitution_mappings:
+    node_type: MyService
+    properties:  
+      num-cpus: cpus
+    capabilities:
+      bar: [ some-service, bar ]
+    requirements:
+      foo: [ some-service, foo ]
+
+  node_templates:
+    some-service:
+      type: MyService
+      properties: 
+        rate: 100
+      capabilities:
+        bar:
+          ...
+      requirements:
+      - foo: 
+          ...
+# EDITOR_TAG:{"type":"example","id":"s47","action":"end"} -->

--- a/tosca_2_0/examples/s48.yaml
+++ b/tosca_2_0/examples/s48.yaml
@@ -1,0 +1,23 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s48","action":"start"} -->
+MyApp:
+  derived_from: SoftwareComponent
+  description: My company's custom application
+  properties:
+    my-app-password:
+      type: string
+      description: Application password
+      validation:
+        $and: 
+        - { $greater_or_equal: [ $value, 6 ] }
+        - { $less_or_equal: [ $value, 10 ] }
+  attributes:
+    my-app-port:
+      type: integer
+      description: Application port number
+  requirements:
+  - some-database:
+      capability: EndPoint.Database
+      node: Database    
+      relationship: ConnectsTo
+# EDITOR_TAG:{"type":"example","id":"s48","action":"end"} -->

--- a/tosca_2_0/examples/s49.yaml
+++ b/tosca_2_0/examples/s49.yaml
@@ -1,0 +1,15 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s49","action":"start"} -->
+node_templates:
+  mysql:
+    type: DBMS.MySQL
+    properties:
+      root-password: { $get_input: my-mysql-rootpw }
+      port: { $get_input: my-mysql-port }
+    requirements:
+    - host: db-server
+    interfaces:
+      standard:
+        operations:
+          configure: scripts/my_own_configure.sh
+# EDITOR_TAG:{"type":"example","id":"s49","action":"end"} -->

--- a/tosca_2_0/examples/s5.yaml
+++ b/tosca_2_0/examples/s5.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s5","action":"start"} -->
+description: This is an example of a single line description (no folding). 
+# EDITOR_TAG:{"type":"example","id":"s5","action":"end"} -->

--- a/tosca_2_0/examples/s50.yaml
+++ b/tosca_2_0/examples/s50.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s50","action":"start"} -->
+AppDependency:
+  derived_from: DependsOn
+  valid_capability_types: [ SomeAppFeature ]
+# EDITOR_TAG:{"type":"example","id":"s50","action":"end"} -->

--- a/tosca_2_0/examples/s51.yaml
+++ b/tosca_2_0/examples/s51.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s51","action":"start"} -->
+relationship_templates:
+  storage-attachment:
+    type: AttachesTo
+    properties:
+      location: /my_mount_point
+# EDITOR_TAG:{"type":"example","id":"s51","action":"end"} -->

--- a/tosca_2_0/examples/s52.yaml
+++ b/tosca_2_0/examples/s52.yaml
@@ -1,0 +1,12 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s52","action":"start"} -->
+MyFeature:
+  description: A custom feature of my company's application
+  properties:
+    my-feature-setting:
+      type: string
+    my-feature-value:
+      type: integer
+  valid_source_node_types:
+  - MyCompanyNodes
+# EDITOR_TAG:{"type":"example","id":"s52","action":"end"} -->

--- a/tosca_2_0/examples/s53.yaml
+++ b/tosca_2_0/examples/s53.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s53","action":"start"} -->
+some-capability: 
+  type: MyCapabilityTypeName
+  properties:
+    limit: 
+      default: 100
+# EDITOR_TAG:{"type":"example","id":"s53","action":"end"} -->

--- a/tosca_2_0/examples/s54.yaml
+++ b/tosca_2_0/examples/s54.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s54","action":"start"} -->
+some-capability: MyCapabilityTypeName
+# EDITOR_TAG:{"type":"example","id":"s54","action":"end"} -->

--- a/tosca_2_0/examples/s55.yaml
+++ b/tosca_2_0/examples/s55.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s55","action":"start"} -->
+node_templates:
+  my-node:
+    capabilities:
+      my-feature:
+        properties:
+          limit: 100
+# EDITOR_TAG:{"type":"example","id":"s55","action":"end"} -->

--- a/tosca_2_0/examples/s56.yaml
+++ b/tosca_2_0/examples/s56.yaml
@@ -1,0 +1,10 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s56","action":"start"} -->
+service_template:
+  node_templates:
+    my-application:
+      type: WebApplication
+      requirements:
+      - host: 
+          node: WebServer
+# EDITOR_TAG:{"type":"example","id":"s56","action":"end"} -->

--- a/tosca_2_0/examples/s57.yaml
+++ b/tosca_2_0/examples/s57.yaml
@@ -1,0 +1,11 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s57","action":"start"} -->
+service_template:
+  node_templates:
+    my-application:
+      type: WebApplication
+      count: 3
+      requirements:
+      - host: 
+          node: [ tomcat-server, $node_index ]
+# EDITOR_TAG:{"type":"example","id":"s57","action":"end"} -->

--- a/tosca_2_0/examples/s58.yaml
+++ b/tosca_2_0/examples/s58.yaml
@@ -1,0 +1,12 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s58","action":"start"} -->
+service_template:
+  node_templates:
+    my-application:
+      type: WebApplication
+      requirements:
+      - database: 
+          node: my-database
+          capability: Endpoint.Database
+          relationship: CustomDbConnection
+# EDITOR_TAG:{"type":"example","id":"s58","action":"end"} -->

--- a/tosca_2_0/examples/s59.yaml
+++ b/tosca_2_0/examples/s59.yaml
@@ -1,0 +1,26 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s59","action":"start"} -->
+capability_types:
+  Service:
+    description: >-
+      Ability to provide service.
+
+relationship_types:
+  ServedBy:
+    description: >-
+      Connection to a service.
+
+node_types:
+  Client:
+    requirements:
+    - service:
+        capability: Service
+        relationship: ServedBy
+        node: Server
+        count_range: [ 1, 4 ]
+
+  Server:
+    capabilities:
+      service:
+        type: Service
+# EDITOR_TAG:{"type":"example","id":"s59","action":"end"} -->

--- a/tosca_2_0/examples/s6.yaml
+++ b/tosca_2_0/examples/s6.yaml
@@ -1,0 +1,5 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s6","action":"start"} -->
+description: "A multiline description 
+using a quoted string"
+# EDITOR_TAG:{"type":"example","id":"s6","action":"end"} -->

--- a/tosca_2_0/examples/s60.yaml
+++ b/tosca_2_0/examples/s60.yaml
@@ -1,0 +1,26 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s60","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+service_template:
+  node_templates:
+    server1:
+      type: Server
+
+    server2:
+      type: Server
+
+    server3:
+      type: Server
+
+    client:
+      type: Client
+      directives: [ substitute ]
+      requirements:
+      - service: server1
+      - service: server2
+      - service: server3
+# EDITOR_TAG:{"type":"example","id":"s60","action":"end"} -->

--- a/tosca_2_0/examples/s61.yaml
+++ b/tosca_2_0/examples/s61.yaml
@@ -1,0 +1,28 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s61","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+
+imports:
+- types.yaml
+
+service_template:
+  node_templates:
+    server1:
+      type: Server
+
+    server2:
+      type: Server
+
+    server3:
+      type: Server
+
+    client:
+      type: Client
+      directives: [ substitute ]
+      requirements:
+      - service: server1
+      - service:
+          optional: true
+      - service:
+          optional: true
+# EDITOR_TAG:{"type":"example","id":"s61","action":"end"} -->

--- a/tosca_2_0/examples/s62.yaml
+++ b/tosca_2_0/examples/s62.yaml
@@ -1,0 +1,12 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s62","action":"start"} -->
+service_template:
+  node_templates:
+    my-application:
+      requirements:
+      - host:
+          node: Compute
+          allocation:
+            num-cpu: 2
+            mem-size: 128 MB
+# EDITOR_TAG:{"type":"example","id":"s62","action":"end"} -->

--- a/tosca_2_0/examples/s63.yaml
+++ b/tosca_2_0/examples/s63.yaml
@@ -1,0 +1,17 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s63","action":"start"} -->
+service_template:
+  node_templates:
+    my-node:
+      # other details omitted for brevity
+      requirements:
+      - host:
+          node_filter:
+            $and:
+              - $in_range:
+                - $get_property: [ SELF, CAPABILITY, num-cpus ]
+                - [ 1, 4 ]
+              - $greater_or_equal:
+                - $get_property: [ SELF, CAPABILITY, mem-size ]
+                - 512 MB 
+# EDITOR_TAG:{"type":"example","id":"s63","action":"end"} -->

--- a/tosca_2_0/examples/s64.yaml
+++ b/tosca_2_0/examples/s64.yaml
@@ -1,0 +1,15 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s64","action":"start"} -->
+node_types:
+  Node:
+    properties:
+      name:
+        type: string
+
+service_template:
+  node_templates:
+    node:
+      type: Node
+      properties:
+        name: "0.1"
+# EDITOR_TAG:{"type":"example","id":"s64","action":"end"} -->

--- a/tosca_2_0/examples/s65.yaml
+++ b/tosca_2_0/examples/s65.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s65","action":"start"} -->
+data_types:
+  UInt16:
+    derived_from: integer
+    validation: { $in_range: [ $value, [ 0, 0xFFFF ] ] }
+# EDITOR_TAG:{"type":"example","id":"s65","action":"end"} -->

--- a/tosca_2_0/examples/s66.yaml
+++ b/tosca_2_0/examples/s66.yaml
@@ -1,0 +1,15 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s66","action":"start"} -->
+node_types:
+  Node:
+    properties:
+      speed:
+        type: float
+
+service_template:
+  node_templates:
+    node:
+      type: Node
+      properties:
+        speed: 10
+# EDITOR_TAG:{"type":"example","id":"s66","action":"end"} -->

--- a/tosca_2_0/examples/s67.yaml
+++ b/tosca_2_0/examples/s67.yaml
@@ -1,0 +1,19 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s67","action":"start"} -->
+ode_types:
+  Node:
+    properties:
+      preamble:
+        type: bytes
+
+service_template:
+  node_templates:
+    node:
+      type: Node
+      properties:
+        preamble: "\
+R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5\
+OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+\
++f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC\
+AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
+# EDITOR_TAG:{"type":"example","id":"s67","action":"end"} -->

--- a/tosca_2_0/examples/s68.yaml
+++ b/tosca_2_0/examples/s68.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s68","action":"start"} -->
+node_types:
+  Node:
+    properties:
+      nothing:
+        type: nil
+        required: true
+
+service_template:
+  node_templates:
+    my-node:
+      type: Node
+      properties:
+        nothing: null
+# EDITOR_TAG:{"type":"example","id":"s68","action":"end"} -->

--- a/tosca_2_0/examples/s69.yaml
+++ b/tosca_2_0/examples/s69.yaml
@@ -1,0 +1,14 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s69","action":"start"} -->
+node_types:
+  Node:
+    properties:
+      nothing:
+        type: nil
+        required: false
+
+service_template:
+  node_templates:
+    my-node:
+      type: Node
+# EDITOR_TAG:{"type":"example","id":"s69","action":"end"} -->

--- a/tosca_2_0/examples/s7.yaml
+++ b/tosca_2_0/examples/s7.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s7","action":"start"} -->
+description: >
+  This is an example of a multi-line description using YAML. It permits for line        
+  breaks for easier readability...
+
+  if needed.  However, (multiple) line breaks are folded into a single space   
+  character when processed into a single string value.
+# EDITOR_TAG:{"type":"example","id":"s7","action":"end"} -->

--- a/tosca_2_0/examples/s70.yaml
+++ b/tosca_2_0/examples/s70.yaml
@@ -1,0 +1,76 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s70","action":"start"} -->
+dsl_definitions:
+  # Defined a reusable set of prefixes taken from ISO80000
+  iso-prefixes: &ISO80000
+    # Prefixes for smaller multipliers ommitted
+    μ: 0.0001
+    m: 0.001
+    c: 0.01
+    d: 0.1
+    "": 1.0 # allows use of the base unit without any prefix
+    da: 10 # units may be muliple characters
+    h: 100 # integer multipliers auto-converted to floats
+    k: 1000
+    M: 1000000
+    # Prefixes for larger multipliers omitted
+
+data_types:
+  PositiveInteger:
+    derived_from: integer
+    validation: { $greater_or_equal: [ $value, 1 ] }
+
+  Bitrate:
+    version: "2.0"
+    description: Data rate allowing multiples of 1024 as well as 1000 but not including prefixes above 10^12
+    derived_from: scalar
+    data_type: PositiveInteger
+    units:
+      bits/s: 1 # This is the mandatory entry with multiplier one
+      bps: 1 # A second entry with multiplier one so a canonical_unit is required
+      kbits/s: 1000 # No prefix defined so unit includes the prefix 'k' and the base unit 'bits/s'
+      Kibits/s: 1024
+      Mbits/s: 1000000
+      Mibits/s: 1048576
+      Gbits/s: 1000000000
+      Gibits/s: 1073741824
+      Tbits/s: 1000000000000
+      Tibits/s: 1099511627776
+    canonical_unit: bits/s
+
+  Length:
+    derived_from: scalar
+    # data_type defaults to float
+    units: 
+      m: 1.0  # Just one entry which defines the base to which defined prefixes are applied
+    # Only one unit so no need for canonical_unit
+    prefixes: *ISO80000 # First use of the YAML anchor and alias
+
+  Mass:
+    derived_from: scalar
+    units: { g: 1 } # Short notation. Integer automatically converted to float
+    prefixes: *ISO80000 # Note map of prefixes is used by both Length and Mass by means of YAML anchor and alias
+
+node_types:
+  Box:
+    properties:
+      weight:
+        type: Mass
+      height:
+        type: Length
+      width:
+        type: Length
+        validation: { $less_than: [ $value, 15 cm ] } # Validation is in centimeters
+      throughput:
+        type: Bitrate
+
+service_template:
+  node_templates:
+    node:
+      type: Box
+      properties:
+        weight: 10 kg # Automatic conversion to float
+        height: 0.1 m
+        width: 125.3 mm # Definition is in millimeters, conversion of units within a scalar is performed by the parser
+        throughput: 10 Kibits/s
+# EDITOR_TAG:{"type":"example","id":"s70","action":"end"} -->

--- a/tosca_2_0/examples/s71.yaml
+++ b/tosca_2_0/examples/s71.yaml
@@ -1,0 +1,58 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s71","action":"start"} -->
+dsl_definitions:
+  iso-prefixes: &ISO80000
+    "": 1
+    k:  1000
+    Ki: 1024
+    M:  1000000
+    Mi: 1048576
+    G:  1000000000
+    Gi: 1073741824
+    T:  1000000000000
+    Ti: 1099511627776
+
+data_types:
+  Bitrate:
+    description: Replacement for "scalar-unit.bitrate"
+    derived_from: scalar
+    data_type: float
+    units:
+      bps: 1 # bits per second
+      Bps: 8 # bytes per second
+    prefixes: *ISO80000
+    validation: { $greater_or_equal: [ $value, 0.0 ] }
+
+  Frequency:
+    description: Replacement for "scalar-unit.frequency"
+    derived_from: scalar
+    data_type: float
+    units:
+      Hz: 1
+    prefixes: *ISO80000
+    validation: { $greater_or_equal: [ $value, 0.0 ] }
+
+  Size:
+    description: Replacement for "scalar-unit.size"
+    derived_from: scalar
+    data_type: integer
+    units:
+      B: 1 # bytes
+    prefixes: *ISO80000
+    validation: { $greater_or_equal: [ $value, 0 ] }
+
+  Time:
+    description: Replacement for "scalar-unit.time"
+    derived_from: scalar
+    data_type: float
+    units:
+      ns: 0.000000001
+      us: 0.000001
+      μs: 0.000001
+      ms: 0.001
+      s:  1
+      m:  60
+      h:  3600
+      d:  86400
+    validation: { $greater_or_equal: [ $value, 0.0 ] }
+# EDITOR_TAG:{"type":"example","id":"s71","action":"end"} -->

--- a/tosca_2_0/examples/s72.yaml
+++ b/tosca_2_0/examples/s72.yaml
@@ -1,0 +1,12 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s72","action":"start"} -->
+# basic version strings
+"6.1"
+2.0.1
+
+# version string with optional qualifier
+3.1.0.beta
+
+# version string with optional qualifier and build version
+1.0.0.alpha-10
+# EDITOR_TAG:{"type":"example","id":"s72","action":"end"} -->

--- a/tosca_2_0/examples/s73.yaml
+++ b/tosca_2_0/examples/s73.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s73","action":"start"} -->
+listen-ports: [ 80, 8080 ]
+# EDITOR_TAG:{"type":"example","id":"s73","action":"end"} -->

--- a/tosca_2_0/examples/s74.yaml
+++ b/tosca_2_0/examples/s74.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s74","action":"start"} -->
+listen-ports:
+- 80
+- 8080
+# EDITOR_TAG:{"type":"example","id":"s74","action":"end"} -->

--- a/tosca_2_0/examples/s75.yaml
+++ b/tosca_2_0/examples/s75.yaml
@@ -1,0 +1,12 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s75","action":"start"} -->
+<some_entity>:
+  ...
+  properties:  
+    listen-ports:
+      type: list
+      entry_schema:
+        description: listen port entry (simple integer type)
+        type: integer
+        validation: { $less_or_equal: [ $value, 128 ] }
+# EDITOR_TAG:{"type":"example","id":"s75","action":"end"} -->

--- a/tosca_2_0/examples/s76.yaml
+++ b/tosca_2_0/examples/s76.yaml
@@ -1,0 +1,11 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s76","action":"start"} -->
+<some_entity>:
+  ...
+  properties:  
+    products:
+      type: list
+      entry_schema:
+        description: Product information entry (complex type) defined elsewhere
+        type: ProductInfo
+# EDITOR_TAG:{"type":"example","id":"s76","action":"end"} -->

--- a/tosca_2_0/examples/s77.yaml
+++ b/tosca_2_0/examples/s77.yaml
@@ -1,0 +1,5 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s77","action":"start"} -->
+# notation option for shorter maps
+user-name-to-id: { user1: 1001, user2: 1002 }
+# EDITOR_TAG:{"type":"example","id":"s77","action":"end"} -->

--- a/tosca_2_0/examples/s78.yaml
+++ b/tosca_2_0/examples/s78.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s78","action":"start"} -->
+# notation for longer maps
+user-name-to-id:
+  user1: 1001
+  user2: 1002
+# EDITOR_TAG:{"type":"example","id":"s78","action":"end"} -->

--- a/tosca_2_0/examples/s79.yaml
+++ b/tosca_2_0/examples/s79.yaml
@@ -1,0 +1,12 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s79","action":"start"} -->
+<some_entity>:
+  ...
+  properties:  
+    emails:
+      type: map
+      entry_schema:
+        description: basic email address
+        type: string
+        validation: { $less_or_equal: [ $value, 128 ] }
+# EDITOR_TAG:{"type":"example","id":"s79","action":"end"} -->

--- a/tosca_2_0/examples/s8.yaml
+++ b/tosca_2_0/examples/s8.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s8","action":"start"} -->
+tosca_definitions_version: <tosca_version> 
+# EDITOR_TAG:{"type":"example","id":"s8","action":"end"} -->

--- a/tosca_2_0/examples/s80.yaml
+++ b/tosca_2_0/examples/s80.yaml
@@ -1,0 +1,11 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s80","action":"start"} -->
+<some_entity>:
+  ...
+  properties:  
+    contacts:
+      type: map
+      entry_schema:
+        description: simple contact information
+        type: ContactInfo
+# EDITOR_TAG:{"type":"example","id":"s80","action":"end"} -->

--- a/tosca_2_0/examples/s81.yaml
+++ b/tosca_2_0/examples/s81.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s81","action":"start"} -->
+ShortString:
+  derived_from: string
+  validation: { $less_or_equal: [ $value, 16 ] }
+# EDITOR_TAG:{"type":"example","id":"s81","action":"end"} -->

--- a/tosca_2_0/examples/s82.yaml
+++ b/tosca_2_0/examples/s82.yaml
@@ -1,0 +1,11 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s82","action":"start"} -->
+PhoneNumber:
+  properties:
+    country-code:
+      type: integer
+    area-code:
+      type: integer
+    number:
+      type: integer
+# EDITOR_TAG:{"type":"example","id":"s82","action":"end"} -->

--- a/tosca_2_0/examples/s83.yaml
+++ b/tosca_2_0/examples/s83.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s83","action":"start"} -->
+ExtendPhoneNumber:
+  derived_from: PhoneNumber
+  properties:
+    phone-description:
+      type: string
+      validation: { $less_or_equal: [ $value, 128 ] }
+# EDITOR_TAG:{"type":"example","id":"s83","action":"end"} -->

--- a/tosca_2_0/examples/s84.yaml
+++ b/tosca_2_0/examples/s84.yaml
@@ -1,0 +1,10 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s84","action":"start"} -->
+properties:
+  num-cpus:
+    type: integer
+    description: Number of CPUs requested for a software node instance.
+    default: 1
+    required: true
+    validation: { $valid_values: [ $value, [ 1, 2, 4, 8 ] ] }
+# EDITOR_TAG:{"type":"example","id":"s84","action":"end"} -->

--- a/tosca_2_0/examples/s85.yaml
+++ b/tosca_2_0/examples/s85.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s85","action":"start"} -->
+Endpoint:
+  properties:
+    protocol:
+      type: string
+      required: true
+      default: tcp
+    port:
+      type: PortDef
+      required: false
+    secure:
+      type: boolean
+      required: false
+      default: false
+# EDITOR_TAG:{"type":"example","id":"s85","action":"end"} -->

--- a/tosca_2_0/examples/s86.yaml
+++ b/tosca_2_0/examples/s86.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s86","action":"start"} -->
+Endpoint.Admin:
+  derived_from: Endpoint
+  # Change Endpoint secure indicator to true from its default of false
+  properties:
+    secure: true
+# EDITOR_TAG:{"type":"example","id":"s86","action":"end"} -->

--- a/tosca_2_0/examples/s87.yaml
+++ b/tosca_2_0/examples/s87.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s87","action":"start"} -->
+actual_cpus:
+  type: integer
+  description: Actual number of CPUs allocated to the node instance.
+# EDITOR_TAG:{"type":"example","id":"s87","action":"end"} -->

--- a/tosca_2_0/examples/s88.yaml
+++ b/tosca_2_0/examples/s88.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s88","action":"start"} -->
+inputs:
+  cpus:
+    type: integer
+    description: Number of CPUs for the server.
+    validation: { $valid_values: [ $value, [ 1, 2, 4, 8 ] ] }
+# EDITOR_TAG:{"type":"example","id":"s88","action":"end"} -->

--- a/tosca_2_0/examples/s89.yaml
+++ b/tosca_2_0/examples/s89.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s89","action":"start"} -->
+outputs:
+  server-ip:
+    description: The private IP address of the provisioned server.
+    value: { $get_attribute: [ my-server, private-address ] }
+# EDITOR_TAG:{"type":"example","id":"s89","action":"end"} -->

--- a/tosca_2_0/examples/s9.yaml
+++ b/tosca_2_0/examples/s9.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s9","action":"start"} -->
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s9","action":"end"} -->

--- a/tosca_2_0/examples/s90.yaml
+++ b/tosca_2_0/examples/s90.yaml
@@ -1,0 +1,23 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s90","action":"start"} -->
+data_types:
+  # Full function syntax for the $value function
+  Count1:
+    derived_from: integer
+    validation: { $greater_or_equal: [ { $value: [] }, 0 ] }
+
+  # Simple function syntax for the $value function
+  Count2:
+    derived_from: integer
+    validation: { $greater_or_equal: [ $value, 0 ] }
+
+  # Full function syntax with arguments
+  SizeRange:
+    properties:
+      low:
+        type: float
+      high:
+        type: float
+    validation:
+      $greater_or_equal: [ { $value: [ high ] }, { $value: [ low ] } ]
+# EDITOR_TAG:{"type":"example","id":"s90","action":"end"} -->

--- a/tosca_2_0/examples/s91.yaml
+++ b/tosca_2_0/examples/s91.yaml
@@ -1,0 +1,26 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s91","action":"start"} -->
+node_types:
+  Scalable:
+    properties:
+      minimum-instances:
+        type: integer
+        validation: { $greater_or_equal: [ $value,  0 ] } 
+      maximum-instances:
+        type: integer
+        validation: 
+          $greater_or_equal:
+          - $value
+          - $get_property: [ SELF, minimum-instances ]
+      default-instances:
+        type: integer
+        validation:
+          $and:
+          - $greater_or_equal: 
+            - $value
+            - $get_property: [ SELF, minimum-instances ]
+          - $less_or_equal: 
+            - $value
+            - $get_property: [ SELF, maximum-instances ]
+        required: false
+# EDITOR_TAG:{"type":"example","id":"s91","action":"end"} -->

--- a/tosca_2_0/examples/s92.yaml
+++ b/tosca_2_0/examples/s92.yaml
@@ -1,0 +1,7 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s92","action":"start"} -->
+hint:
+  { $keygen: [ UUID ] }: 34
+  { $keygen$1: [ UUID ] }: 56
+  { $keygen$2: [ UUID ] }: 78
+# EDITOR_TAG:{"type":"example","id":"s92","action":"end"} -->

--- a/tosca_2_0/examples/s93.yaml
+++ b/tosca_2_0/examples/s93.yaml
@@ -1,0 +1,5 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s93","action":"start"} -->
+properties:
+  context: { $get_security_context: { env: staging, role: admin } }
+# EDITOR_TAG:{"type":"example","id":"s93","action":"end"} -->

--- a/tosca_2_0/examples/s94.yaml
+++ b/tosca_2_0/examples/s94.yaml
@@ -1,0 +1,5 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s94","action":"start"} -->
+properties:
+  nested: { $outer_func: [ { $inner_func: [ iarg1, iarg2 ] }, oarg2 ] }
+# EDITOR_TAG:{"type":"example","id":"s94","action":"end"} -->

--- a/tosca_2_0/examples/s95.yaml
+++ b/tosca_2_0/examples/s95.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s95","action":"start"} -->
+properties:
+  prop1:
+   $$myid1: myval1
+   myid2: $$myval2
+   $$myid3: $$myval3
+# EDITOR_TAG:{"type":"example","id":"s95","action":"end"} -->

--- a/tosca_2_0/examples/s96.yaml
+++ b/tosca_2_0/examples/s96.yaml
@@ -1,0 +1,4 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s96","action":"start"} -->
+$get_input: [ <input_parameter_name>, <nested_input_parameter_name_or_index_1>, <nested_input_parameter_name_or_index_2>, ... ]
+# EDITOR_TAG:{"type":"example","id":"s96","action":"end"} -->

--- a/tosca_2_0/examples/s97.yaml
+++ b/tosca_2_0/examples/s97.yaml
@@ -1,0 +1,14 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s97","action":"start"} -->
+inputs:
+  cpus:
+    type: integer
+
+node_templates:
+  my-server:
+    type: Compute
+    capabilities:
+      host:
+        properties:
+          num-cpus: { $get_input: cpus }
+# EDITOR_TAG:{"type":"example","id":"s97","action":"end"} -->

--- a/tosca_2_0/examples/s98.yaml
+++ b/tosca_2_0/examples/s98.yaml
@@ -1,0 +1,39 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s98","action":"start"} -->
+data_types:
+  NetworkInfo:
+    properties:
+      name:
+        type: string
+      gateway:
+        type: string
+
+RouterInfo:
+    properties:
+      ip:
+        type: string
+      external:
+        type: string
+
+service_template:
+  inputs:
+    management-network:
+      type: NetworkInfo
+    router:
+      type: RouterInfo
+
+  node_templates:
+    bono-main:
+      type: vRouter.Cisco
+      directives: [ substitutable ]
+      properties:
+        mgmt-net-name: { $get_input: [ management-network, name ] }
+        mgmt-cp-v4-fixed-ip: { $get_input: [ router, ip ] }
+        mgmt-cp-gateway-ip: { $get_input: [ management-network, gateway ] }
+        mgmt-cp-external-ip: { $get_input: [ router, external ] }
+      requirements:
+        - lan-port:
+            node: host-with-net
+            capability: VirtualBind
+        - mgmt-net: mgmt-net
+# EDITOR_TAG:{"type":"example","id":"s98","action":"end"} -->

--- a/tosca_2_0/examples/s99.yaml
+++ b/tosca_2_0/examples/s99.yaml
@@ -1,0 +1,17 @@
+tosca_definitions_version: tosca_2_0
+# EDITOR_TAG:{"type":"example","id":"s99","action":"start"} -->
+node_templates:
+  mysql-database:
+    type: Database
+    properties:
+      name: sql_database1
+
+  wordpress:
+    type: WordPress
+    ...
+    interfaces:
+      standard:
+        configure: 
+          inputs:
+            wp-db-name: { $get_property: [ mysql-database, name ] }
+# EDITOR_TAG:{"type":"example","id":"s99","action":"end"} -->


### PR DESCRIPTION
Wrapped all TOSCA examples in the spec with start and end tags containing unique IDs. Copied each example from the spec into the examples directory, wrapped and named with the matching ID value. All examples have a TOSCA header prepended before the tag but none have yet been checked for validity.